### PR TITLE
Add optional pagination to models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,4 @@ gem "delayed_job_active_record", "~> 4.1"
 gem "activerecord-nulldb-adapter", "~> 0.8.0"
 
 gem "memoist", "~> 0.16.2"
-gem 'will_paginate', '~> 3.3'
+gem "will_paginate", "~> 3.3"

--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ gem "delayed_job_active_record", "~> 4.1"
 gem "activerecord-nulldb-adapter", "~> 0.8.0"
 
 gem "memoist", "~> 0.16.2"
+gem 'will_paginate', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.3.1)
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -351,9 +352,10 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 4.1.0)
   webpacker (~> 5.4)
+  will_paginate (~> 3.3)
 
 RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.15
+   2.2.28

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ The server will then be running at http://127.0.0.1:5000
 
 `bundle exec rake`
 
+### Configuration
+
+#### Pagination
+
+Models are displayed with continuous scroll, but you can alternately choose to paginate them.
+
+To enable pagination, modify config/application.rb to include:
+```ruby
+config.paginate_models = true
+```
+
 ## Credits
 
 Built with [Rails 6](https://rubyonrails.org/) and

--- a/app/assets/stylesheets/models.scss
+++ b/app/assets/stylesheets/models.scss
@@ -1,3 +1,12 @@
 // Place all the styles related to the Models controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.paginate-container {
+  .pagination {
+    a {
+      padding: 0 0.5em;
+    }
+  }
+}
+

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -10,7 +10,14 @@ class LibrariesController < ApplicationController
   end
 
   def show
-    @models = @library.models.includes(:tags, :preview_file, :creator)
+    @models =
+    if Rails.application.config.paginate_models
+      page = params[:page] || 1
+      @library.models.includes(:tags, :preview_file, :creator).paginate(page: page, per_page: 5)
+    else
+      @library.models.includes(:tags, :preview_file, :creator)
+    end
+
     @tags = @models.map(&:tags).flatten.uniq.sort_by(&:name)
     @scanning = Delayed::Job.count > 0
     # Filter by tag?

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -11,12 +11,12 @@ class LibrariesController < ApplicationController
 
   def show
     @models =
-    if Rails.application.config.paginate_models
-      page = params[:page] || 1
-      @library.models.includes(:tags, :preview_file, :creator).paginate(page: page)
-    else
-      @library.models.includes(:tags, :preview_file, :creator)
-    end
+      if Rails.application.config.paginate_models
+        page = params[:page] || 1
+        @library.models.includes(:tags, :preview_file, :creator).paginate(page: page)
+      else
+        @library.models.includes(:tags, :preview_file, :creator)
+      end
 
     @tags = @models.map(&:tags).flatten.uniq.sort_by(&:name)
     @scanning = Delayed::Job.count > 0

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -13,7 +13,7 @@ class LibrariesController < ApplicationController
     @models =
     if Rails.application.config.paginate_models
       page = params[:page] || 1
-      @library.models.includes(:tags, :preview_file, :creator).paginate(page: page, per_page: 5)
+      @library.models.includes(:tags, :preview_file, :creator).paginate(page: page)
     else
       @library.models.includes(:tags, :preview_file, :creator)
     end

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -4,6 +4,11 @@
     <div class="row row-cols-2 row-cols-md-3 mb-4">
       <%= render partial: 'model', collection: @models %>
     </div>
+    <% if Rails.application.config.paginate_models %>
+      <div class="paginate-container">
+        <%= will_paginate @models %>
+      </div>
+    <% end %>
   </div>
   <div class="col-3">
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,6 @@ module VanDam
     config.generators.system_tests = nil
 
     config.formats = config_for(:formats)
+    config.paginate_models = false
   end
 end

--- a/spec/requests/libraries_request_spec.rb
+++ b/spec/requests/libraries_request_spec.rb
@@ -18,4 +18,13 @@ RSpec.describe "Libraries", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "GET /libraries/1?page=2" do
+    it "returns paginated models" do
+      allow(Rails.application.config).to receive(:paginate_models).and_return(true)
+      get "/libraries/1?page=2"
+      expect(response).to have_http_status(:success)
+      expect(response.body).to match(/paginate-container/)
+    end
+  end
 end


### PR DESCRIPTION
This adds optional basic pagination when viewing library models.

There's definitely room for better styling and additional configuration, but I didn't want to take this too far for the initial PR.