### PR TITLE
Minor tweaks to preview

### DIFF
--- a/app/javascript/src/preview.ts
+++ b/app/javascript/src/preview.ts
@@ -30,10 +30,9 @@ class ObjectPreview {
   }
 
   onIntersectionChanged (entries, observer): void {
+    this.cleanup()
     if (entries[0].isIntersecting === true) {
       this.load(this.url, this.format)
-    } else {
-      this.cleanup()
     }
   }
 
@@ -105,6 +104,7 @@ class ObjectPreview {
     // Configure camera
     this.camera.position.z = this.camera.position.x = bsphere.radius * 1.63
     this.camera.position.y = bsphere.radius * 0.75
+
     this.controls.target = new THREE.Vector3(0, modelheight / 2, 0)
     // Centre the model
     object.position.set(-centre.x, -bbox.min.y, -centre.z)
@@ -114,6 +114,10 @@ class ObjectPreview {
     this.scene.add(this.gridHelper)
     // Render first frame
     this.onAnimationFrame()
+
+    bbox.dispose()
+    centre.dispose()
+    bsphere.dispose()
   }
 
   onLoadError (): void {


### PR DESCRIPTION
This makes a few tweaks to the preview code to help with cleanup.
Since `onLoad` calls setup, it makes sense to me that we ought to call cleanup beforehand.
I think this is a little bit better performance wise, but there's still a lot of work to do here.
Ideally, we should only be rendering tiles within the viewport and then immediately cleaning them up, but this doesn't seem to be the case.