### PR TITLE
Create tags from filename and filter stopwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,4 @@ gem "activerecord-nulldb-adapter", "~> 0.8.0"
 
 gem "memoist", "~> 0.16.2"
 gem "will_paginate", "~> 3.3"
+gem "stopwords-filter", require: 'stopwords'

--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,4 @@ gem "activerecord-nulldb-adapter", "~> 0.8.0"
 
 gem "memoist", "~> 0.16.2"
 gem "will_paginate", "~> 3.3"
-gem "stopwords-filter", require: 'stopwords'
+gem "stopwords-filter", require: "stopwords"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,7 @@ GEM
       rack
       rails (>= 5.2)
       redis
+    stopwords-filter (0.7.0)
     temple (0.8.2)
     thor (1.2.1)
     thread-local (1.1.0)
@@ -348,6 +349,7 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   standard (~> 1.10.0)
   stimulus_reflex (~> 3.4)
+  stopwords-filter
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -15,8 +15,12 @@ class Model < ApplicationRecord
   acts_as_taggable_on :tags
 
   def autogenerate_tags_from_path!
-    tag_list.add(path.split(File::SEPARATOR)[1..-2].map { |y| y.split(/[\W_+-]/).filter { |x| x.length > 1 } }.flatten)
-    save!
+    @filter ||= Stopwords::Snowball::Filter.new "en"
+    tags = @filter.filter(File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 })
+    unless tags.empty?
+      tag_list.add(tags)
+      save!
+    end
   end
 
   def parent


### PR DESCRIPTION
The tag generating code seems to be making assumptions about the path that models will have.
I believe this is because of this indexing here
```ruby
    tag_list.add(path.split(File::SEPARATOR)[1..-2].map { |y| y.split(/[\W_+-]/).filter { |x| x.length > 1 } }.flatten)
```
On my mac, this results in a number of models not having any tags generated for them.
You can see that in the first pic. Notice there are only 4 tags. All of those correspond to the first model.

![Screen Shot 2022-04-17 at 11 07 33 AM](https://user-images.githubusercontent.com/732573/163727231-90a313b8-158b-47f4-9cc1-43fcadf35824.png)

I rewrote the tag generation code to be based off the filename and used `File.split` instead of string splitting.
```ruby
    tags = File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 }
```
This resulted in way more models getting tagged.

![Screen Shot 2022-04-17 at 11 10 06 AM](https://user-images.githubusercontent.com/732573/163727367-76fdeda9-1fda-4021-8a6e-48bbdefa82bf.png)

Unfortunately, there are a lot of not very useful tags being generated. To solve that I added a [stop word](https://en.wikipedia.org/wiki/Stop_word) filter. This resulted in a much nicer set of tags, sans words like "the" and "of". 

![Screen Shot 2022-04-17 at 11 11 58 AM](https://user-images.githubusercontent.com/732573/163727457-56e4b596-295b-4959-b862-0b75c9941ae7.png)

The stop word filter [gem](https://github.com/brenes/stopwords-filter) supports multiple languages and user definable stop word sets. I suppose stopword filtering itself should be optional as well. I think these options would make for a nice follow-up PR.

@Floppy  - I did not write model tests for the `autogenerate_tags_from_path!` method because I didn't fully understand the expectations of the original code. I'm happy to do so once I have more clarity with respect to the intent of the original code.
