### PR TITLE
Make pagination default, add missing tests, and move all config into config files

### DIFF
--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -3,7 +3,7 @@ class CreatorsController < ApplicationController
 
   def index
     @creators =
-      if Rails.application.config.paginate_creators
+      if Rails.application.config.pagination.creators
         page = params[:page] || 1
         Creator.all.paginate(page: page)
       else

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -11,7 +11,7 @@ class LibrariesController < ApplicationController
 
   def show
     @models =
-      if Rails.application.config.paginate_models
+      if Rails.application.config.pagination.models
         page = params[:page] || 1
         @library.models.includes(:tags, :preview_file, :creator).paginate(page: page)
       else

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -15,8 +15,14 @@ class Model < ApplicationRecord
   acts_as_taggable_on :tags
 
   def autogenerate_tags_from_path!
-    @filter ||= Stopwords::Snowball::Filter.new "en"
-    tags = @filter.filter(File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 })
+    tags = File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 }
+
+    tags_config = Rails.application.config.tags.models
+    if tags_config[:filter_stop_words]
+      @filter ||= Stopwords::Snowball::Filter.new(tags_config[:stop_words_locale], tags_config[:custom_stop_words])
+      tags = @filter.filter(tags)
+    end
+
     unless tags.empty?
       tag_list.add(tags)
       save!

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -5,7 +5,7 @@
     <div class="row row-cols-2 row-cols-md-3 mb-3">
         <%= render @creators %>
     </div>
-    <% if Rails.application.config.paginate_creators %>
+    <% if Rails.application.config.pagination.creators %>
       <div class="paginate-container">
         <%= will_paginate @creators %>
       </div>

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -4,7 +4,7 @@
     <div class="row row-cols-2 row-cols-md-3 mb-4">
       <%= render partial: 'model', collection: @models %>
     </div>
-    <% if Rails.application.config.paginate_models %>
+    <% if Rails.application.config.pagination.models %>
       <div class="paginate-container">
         <%= will_paginate @models %>
       </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,10 +37,10 @@ module VanDam
 
     config.formats = config_for(:formats)
 
-    config.paginate_models = false
-    config.paginate_creators = false
+    config.pagination = config_for(:pagination)
+    config.tags = config_for(:tags)
 
-    # set global per_page
-    WillPaginate.per_page = 10
+    # # set global per_page
+    WillPaginate.per_page = config.pagination.per_page
   end
 end

--- a/config/pagination.yml
+++ b/config/pagination.yml
@@ -1,0 +1,13 @@
+default: &default
+  models: true    # false for infinite scroll
+  creators: true  # false for infinite scroll
+  per_page: 10
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/tags.yml
+++ b/config/tags.yml
@@ -1,0 +1,15 @@
+default: &default
+  models:
+    filter_stop_words: true
+    stop_words_locale: en
+    custom_stop_words:
+      - stl
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -21,6 +21,82 @@ RSpec.describe Model, type: :model do
     expect(build(:model).model_files).to eq []
   end
 
+  context "tag generation" do
+    context "without stop word filtering" do
+      before :each do
+        allow(Rails.application.config.tags.models).to receive(:[]).with(:filter_stop_words).and_return(false)
+      end
+
+      it "skips single letter tags" do
+        model = build(:model, path: "/library1/stuff/a")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq []
+      end
+
+      it "generates tag from whitespace delimited file names" do
+        model = build(:model, path: "/library1/stuff/this is a fantasy model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["this", "is", "fantasy", "model"]
+      end
+
+      it "generates tag from _ delimited file names" do
+        model = build(:model, path: "/library1/stuff/this-is-a-fantasy-model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["this", "is", "fantasy", "model"]
+      end
+
+      it "generates tag from + delimited file names" do
+        model = build(:model, path: "/library1/stuff/this+is+a+fantasy+model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["this", "is", "fantasy", "model"]
+      end
+
+      it "generates tag from - delimited file names" do
+        model = build(:model, path: "/library1/stuff/this-is-a-fantasy-model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["this", "is", "fantasy", "model"]
+      end
+    end
+
+    context "with stop word filtering" do
+      before :each do
+        allow(Rails.application.config.tags.models).to receive(:[]).with(:filter_stop_words).and_return(true)
+        allow(Rails.application.config.tags.models).to receive(:[]).with(:stop_words_locale).and_return("en")
+        allow(Rails.application.config.tags.models).to receive(:[]).with(:custom_stop_words).and_return(["chicken"])
+      end
+
+      it "generates tags from whitespace delimited file names" do
+        model = build(:model, path: "/library1/stuff/this is a fantasy model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["fantasy", "model"]
+      end
+
+      it "generates tags from _ delimited file names" do
+        model = build(:model, path: "/library1/stuff/this-is-a-fantasy-model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["fantasy", "model"]
+      end
+
+      it "generates tags from + delimited file names" do
+        model = build(:model, path: "/library1/stuff/this+is+a+fantasy+model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["fantasy", "model"]
+      end
+
+      it "generates tags from - delimited file names" do
+        model = build(:model, path: "/library1/stuff/this-is-a-fantasy-model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["fantasy", "model"]
+      end
+
+      it "generates tags and filters custom stop words" do
+        model = build(:model, path: "/library1/stuff/this-is-a-scifi-chicken-model")
+        model.autogenerate_tags_from_path!
+        expect(model.tag_list).to eq ["scifi", "model"]
+      end
+    end
+  end
+
   context "with a library on disk" do
     before :each do
       allow(File).to receive(:exist?).and_call_original

--- a/spec/requests/creators_request_spec.rb
+++ b/spec/requests/creators_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Creators", type: :request do
   end
   describe "GET /creators?page=2" do
     it "returns paginated creators" do
-      allow(Rails.application.config).to receive(:paginate_creators).and_return(true)
+      allow(Rails.application.config.pagination).to receive(:creators).and_return(true)
       get "/creators?page=2"
       expect(response).to have_http_status(:success)
       expect(response.body).to match(/pagination/)

--- a/spec/requests/libraries_request_spec.rb
+++ b/spec/requests/libraries_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Libraries", type: :request do
 
   describe "GET /libraries/{id}?page=2" do
     it "returns paginated models" do
-      allow(Rails.application.config).to receive(:paginate_models).and_return(true)
+      allow(Rails.application.config.pagination).to receive(:models).and_return(true)
       get "/libraries/#{@library.id}?page=2"
       expect(response).to have_http_status(:success)
       expect(response.body).to match(/pagination/)


### PR DESCRIPTION
Per previous discussion with @Floppy in #480, this PR makes pagination the default browsing mode.

I also added the missing tests from the tag PR [here](https://github.com/Floppy/van_dam/pull/482).

I didn't want to keep adding things to `config/application.rb` so I created config files for pagination and tags.

Closes #480 