### PR TITLE
show all tags in library taglist

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -18,7 +18,8 @@ class LibrariesController < ApplicationController
         @library.models.includes(:tags, :preview_file, :creator)
       end
 
-    @tags = @models.map(&:tags).flatten.uniq.sort_by(&:name)
+    @tags = @library.models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name)
+
     @scanning = Delayed::Job.count > 0
     # Filter by tag?
     if params[:tag]


### PR DESCRIPTION
The library view was only showing tags for models on the current page. 
It should show all tags for all models in the library.
This fixes #499 