### PR TITLE
Set default pagination size to 12

### DIFF
--- a/config/pagination.yml
+++ b/config/pagination.yml
@@ -1,7 +1,7 @@
 default: &default
   models: true    # false for infinite scroll
   creators: true  # false for infinite scroll
-  per_page: 10
+  per_page: 12
 
 development:
   <<: *default

--- a/spec/requests/creators_request_spec.rb
+++ b/spec/requests/creators_request_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Creators", type: :request do
   before :all do
-    11.times do
+    13.times do
       FactoryBot.create(:creator) do |creator|
         FactoryBot.create_list(:link, 1, linkable: creator)
         FactoryBot.create_list(:model, 1, creator: creator)

--- a/spec/requests/libraries_request_spec.rb
+++ b/spec/requests/libraries_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Libraries", type: :request do
   before :all do
     @library = FactoryBot.create(:library) do |library|
-      FactoryBot.create_list(:model, 11, library: library)
+      FactoryBot.create_list(:model, 13, library: library)
     end
   end
 


### PR DESCRIPTION
It's more divisible than 10, so tends to work better as a page size for a grid of elements