### PR TITLE
refactor: add typing's for typescript

### DIFF
--- a/app/javascript/src/bulk_edit.ts
+++ b/app/javascript/src/bulk_edit.ts
@@ -1,4 +1,4 @@
-function updateTagOptions (tags, input, addTags = true): void {
+function updateTagOptions (tags: string[], input, addTags = true): void {
   tags.forEach((tag) => {
     if (addTags) {
       input.addOption({ value: tag, text: tag })
@@ -11,23 +11,37 @@ function updateTagOptions (tags, input, addTags = true): void {
 
 function getTags (modelId: string): string[] {
   const selector = `[data-bulk-item-tags="${modelId}"]`
-  const tagLinks = document.querySelectorAll(selector)
-  return Array.prototype.slice.call(tagLinks).map((tag) => (tag.innerText))
+  const tagLinks = document.querySelectorAll(
+    selector
+  )
+  return Array.prototype.slice
+    .call(tagLinks)
+    .map((tag: HTMLAnchorElement) => tag.innerHTML)
 }
 
 function handleCheckboxChange (event): void {
+  const target = event.target as HTMLInputElement
+  const { name } = target
   event.preventDefault()
-  if (event.target.name === 'bulk-select-all') {
-    document.querySelectorAll('[data-bulk-item]').forEach((cb): boolean => {
-      cb.checked = !(cb.checked as boolean)
-    })
+  console.log({ target }, { name })
+  // the bulk select checkbox has been selected
+  if (target.name === 'bulk-select-all') {
+    document
+      .querySelectorAll('[data-bulk-item]')
+      .forEach((checkbox: HTMLInputElement) => {
+        checkbox.checked = target.checked
+      })
   } else {
-    const modelId = event.target.getAttribute('data-bulk-item') as string
+    // a single checkbox item has been selected.
+    const modelId = target.getAttribute('data-bulk-item') as string
     if (modelId != null) {
       const tags = getTags(modelId)
+
       if (tags.length > 0 && window.tagInputs != null) {
+        const { tagInputs } = window
+        console.log({ tagInputs })
         window.tagInputs.forEach((input) => {
-          updateTagOptions(tags, input[0].selectize, event.target.checked)
+          updateTagOptions(tags, input[0].selectize, target.checked)
         })
       }
     }
@@ -35,7 +49,9 @@ function handleCheckboxChange (event): void {
 }
 
 document.addEventListener('turbolinks:load', () => {
-  const bulkEditTable = document.querySelector('[data-bulk-edit]')
+  const bulkEditTable = document.querySelector(
+    '[data-bulk-edit]'
+  )
   if (bulkEditTable != null) {
     bulkEditTable.removeEventListener('change', handleCheckboxChange)
     bulkEditTable.addEventListener('change', handleCheckboxChange)

--- a/app/javascript/src/globals.d.ts
+++ b/app/javascript/src/globals.d.ts
@@ -1,0 +1,10 @@
+import { ObjectPreview } from './preview'
+
+declare global {
+  interface Window {
+    tagInputs: Array<JQuery<HTMLElement>>
+  }
+  interface HTMLCanvasElement {
+    renderer: ObjectPreview
+  }
+}

--- a/app/javascript/src/model_edit.ts
+++ b/app/javascript/src/model_edit.ts
@@ -4,8 +4,7 @@ document.addEventListener('turbolinks:load', () => {
     function () {
       const tagInput = $(this).selectize({
         create: true,
-        sortField: 'text',
-        maxItems: null
+        sortField: 'text'
       })
       window.tagInputs.push(tagInput)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "van-dam",
   "private": true,
+  "scripts": {
+    "lint:ts": "ts-standard --fix"
+  },
   "dependencies": {
     "@babel/preset-typescript": "^7.17.12",
     "@nathanvda/cocoon": "^1.2.14",
@@ -23,6 +26,11 @@
   "version": "0.1.0",
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",
+    "@types/jquery": "^3.5.14",
+    "@types/node": "^18.0.0",
+    "@types/selectize": "^0.12.35",
+    "@types/three": "^0.141.0",
+    "@types/webpack-env": "^1.17.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
     "husky": "^8.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,18 +8,21 @@
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-        "*": ["node_modules/*", "app/javascript/*"]
+      "*": ["node_modules/*", "app/javascript/*"]
     },
     "sourceMap": true,
     "strictNullChecks": true,
     "target": "es5",
-    "noEmit": true
+    "noEmit": true,
+    "types": [
+      "./app/javascript/src/globals",
+      "node",
+      "webpack-env",
+      "three",
+      "jquery",
+      "selectize"
+    ]
   },
-  "exclude": [
-    "**/*.spec.ts",
-    "node_modules",
-    "vendor",
-    "public"
-  ],
+  "exclude": ["**/*.spec.ts", "node_modules", "vendor", "public"],
   "compileOnSave": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/jquery@^3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.5.14.tgz#ac8e11ee591e94d4d58da602cb3a5a8320dee577"
+  integrity sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==
+  dependencies:
+    "@types/sizzle" "*"
+
 "@types/json-schema@^7.0.5":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -1564,6 +1571,11 @@
   version "14.14.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
   integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
+
+"@types/node@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
+  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1590,6 +1602,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
+"@types/selectize@^0.12.35":
+  version "0.12.35"
+  resolved "https://registry.yarnpkg.com/@types/selectize/-/selectize-0.12.35.tgz#61cc9353f21e09b267a5a8b133cf819706562d39"
+  integrity sha512-OtutSd9mfyl2qjxNABguUGhwRmHcJRYqRNQEUVBC6QIw0P0DKbhsAF5RUhid1L0GdYGNef8l73kSB1KVpazXqA==
+
 "@types/serve-index@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
@@ -1605,12 +1622,34 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/sizzle@*":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
+  integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
+
 "@types/sockjs@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
   integrity sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
   dependencies:
     "@types/node" "*"
+
+"@types/three@^0.141.0":
+  version "0.141.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.141.0.tgz#d9d81a54b28ebc2a56931dfd4d9c54d25c20d6c8"
+  integrity sha512-OJdKDgTPVBUgc+s74DYoy4aLznbFFC38Xm4ElmU1YwGNgR7GGFVvFCX7lpVgOsT6S1zSJtGdajTsOYE8/xY9nA==
+  dependencies:
+    "@types/webxr" "*"
+
+"@types/webpack-env@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.17.0.tgz#f99ce359f1bfd87da90cc4a57cab0a18f34a48d0"
+  integrity sha512-eHSaNYEyxRA5IAG0Ym/yCyf86niZUIF/TpWKofQI/CVfh5HsMEUyfE2kwFxha4ow0s5g0LfISQxpDKjbRDrizw==
+
+"@types/webxr@*":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.4.0.tgz#ad06c96a324293e0d5175d13dd5ded5931f90ba3"
+  integrity sha512-LQvrACV3Pj17GpkwHwXuTd733gfY+D7b9mKdrTmLdO7vo7P/o6209Qqtk63y/FCv/lspdmi0pWz6Qe/ull9kQg==
 
 "@types/ws@^8.5.1":
   version "8.5.3"


### PR DESCRIPTION
The typescript compiler in vs-code was giving lots of red squiggly lines so have added the needed types and type definition files to help when editing in the future. 

added app/javascript/src/globals.d.ts so now you get intelligence when typing

There were also a few methods called that do not exist, I did check the three docs and also initially wrapped them in a try/catch block and they threw, so removed them also. 

bbox.dispose()
centre.dispose()
bsphere.dispose()

In app/javascript/src/model_edit.ts

removed the maxitem= null as this is the default, and ts requires a number if a value is supplied

In package.json  added a script option to run the ts-standard as used in husky so you can now do a: yarn run lint:ts 

Would it be useful to run a  tslint and prettier and or add a config to the project to keep things tidy and consistent? I'm not a ruby guy so not shure how it does things just yet.
