### PR TITLE
Fix delayed job in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter = :delayed_job
   # config.active_job.queue_name_prefix = "van_dam_production"
 
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :delayed_job
-  # config.active_job.queue_name_prefix = "van_dam_production"
+  config.active_job.queue_name_prefix = "van_dam_production"
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = {host: "localhost", port: 5000}


### PR DESCRIPTION
This config was removed accidentally during the Rails 7 upgrade, so it was using `async` by default.