### PR TITLE
fix: 🐛 no preview model layout shift in grid

### DIFF
--- a/app/assets/stylesheets/models.scss
+++ b/app/assets/stylesheets/models.scss
@@ -12,8 +12,8 @@
   }
 }
 
-.form-check-label{
-  input.checkbox{
+.form-check-label {
+  input.checkbox {
     margin-right: 0.25em;
   }
 }
@@ -23,3 +23,70 @@ div.form-control.tag-container {
   padding: 0;
 }
 
+.model-card {
+  min-height: 100%;
+
+  .image-preview {
+    min-width: 100%;
+  }
+
+  .preview-empty {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    aspect-ratio: 1;
+    border-bottom:solid 2px #fbfbfb;
+    text-transform: capitalize;
+    font-size: .75rem;
+
+    p{
+      position: absolute;
+      padding: 0;
+      margin-block-end: 0;
+      text-align: center;
+      z-index: 50;
+      font-weight: 500;
+    }
+
+    &::before,&::after {
+      content: '';
+      position: absolute;
+      top: -20%;
+      left: 50%;
+      width: 1px;
+      height: 140%;
+      background-color: #333;
+      transform: rotate(45deg);
+      border-radius: 1px;
+      opacity: .08;
+    }
+&::after {
+  transform: rotate(-45deg);
+}
+
+  }
+
+  .card-body {
+    display: flex;
+    flex-direction: column;
+    max-height: fit-content;
+    gap: 0.5rem;
+    justify-content: space-between;
+  }
+
+  .card-title {
+    margin-bottom: 0;
+  }
+
+  .btn {
+    width: fit-content;
+    height: fit-content;
+  }
+
+  small {
+    text-transform: capitalize;
+    font-size: 0.8rem;
+  }
+}

--- a/app/views/application/_model.html.erb
+++ b/app/views/application/_model.html.erb
@@ -1,5 +1,5 @@
 <div class="col mb-4">
-  <div class="card">
+  <div class="card model-card">
     <% if file = model.preview_file %>
       <% if image?(file.file_format) %>
         <%= image_tag library_model_model_file_path(model.library, model, file, format: file.file_format), class: "card-img-top image-preview ", alt: file.name %>
@@ -7,14 +7,16 @@
         <div class="card-img-top">
           <%= render partial: "object_preview", locals: { library: model.library, model: model, file: file } %>
         </div>
-      <% end %>
+      <% end %>  
+       <% else %> 
+       <div class='preview-empty'> <p>no preview availiable</p></div>
     <% end %>
     <div class="card-body">
-      <%= link_to "Open", [model.library, model], {class: "btn btn-primary float-end"} %>
       <h5 class="card-title"><%= model.name %></h5>
       <% if @creator.nil? && model.creator %>
         <small>by <%= link_to model.creator.name, model.creator %></small>
       <% end %>
+      <%= link_to "Open", [model.library, model], {class: "btn btn-primary float-end btn-sm"} %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
If the file type is not supported or unable to create a preview in the grid layout of the models there is now no layout shift.

Cards are all one size now in a row even if there is no creator text

Added a no-preview div to card.

Added css to the card-body to stop the title wrapping  so early at smaller viewports and  the section more consistent.

![Screenshot 2022-06-28 120843](https://user-images.githubusercontent.com/1886110/176165391-0a242eb8-597a-42fd-9a97-f16993c806f5.png)
.