### PR TITLE
fix(css): reorder css in main html layout  so our css renders last

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-  <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 </head>
 
   <body>


### PR DESCRIPTION
Previously if you wrote css that need to overwrite something in a class in bootstrap, you need to nest it or add a dreaded !important  to increase the specificity of it. 
By swapping the imports the in the main pages html, we can now override any vendor styles and if need be add our own theme by  overwriting the css variables in the app.