### PR TITLE
Filter out existing files at the start of library scan

### DIFF
--- a/app/jobs/library_scan_job.rb
+++ b/app/jobs/library_scan_job.rb
@@ -10,6 +10,11 @@ class LibraryScanJob < ApplicationJob
   def perform(library)
     # For each directory in the library, create a model
     all_3d_files = Dir.glob(File.join(library.path, "**", LibraryScanJob.file_pattern))
+    existing_files = library.model_files.reload.map do |x|
+      File.join(library.path, x.model.path, x.filename)
+    end
+    all_3d_files -= existing_files
+    puts all_3d_files.inspect
     model_folders = all_3d_files.map { |f| File.dirname(f) }.uniq
     model_folders = model_folders.map { |f| f.gsub(/\/files$/, "").gsub(/\/images$/, "") }.uniq # Ignore thingiverse subfolders
     model_folders.each do |path|

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe LibraryScanJob, type: :job do
     expect { LibraryScanJob.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(4).times
   end
 
+  it "only scans models with changes on rescan" do
+    model_one = create(:model, path: "model_one", library: library)
+    ModelScanJob.perform_now(model_one)
+    expect { LibraryScanJob.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(3).times
+  end
+
   it "removes models with no files" do
     lib = create(:library, path: File.join("/", "tmp"))
     create(:model, library: lib, path: "missing")


### PR DESCRIPTION
makes things faster, though not ideal. Resolves #565 for now.