### PR TITLE
Add the ability to organise models on disk

### DIFF
--- a/app/assets/stylesheets/model_files.scss
+++ b/app/assets/stylesheets/model_files.scss
@@ -6,12 +6,11 @@
 .object-preview {
 
   .progress {
-    width: 80%
+    width: 80%;
   }
 
   canvas {
     width: 100%;
-    z-index: 10000;
   }
 
 }

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -89,6 +89,7 @@ class ModelsController < ApplicationController
       :name,
       :scale_factor,
       :tags,
+      :path,
       links_attributes: [:id, :url, :_destroy]
     )
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -53,6 +53,10 @@ class Model < ApplicationRecord
     destroy
   end
 
+  def formatted_path
+    File.join("", tags.order(taggings_count: :desc).map(&:to_s).map(&:parameterize), name.parameterize) + "##{id}"
+  end
+
   def contained_models
     library.models.where("path LIKE ?", Model.sanitize_sql_like(path) + "/%")
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -53,6 +53,14 @@ class Model < ApplicationRecord
     destroy
   end
 
+  def contained_models
+    library.models.where("path LIKE ?", Model.sanitize_sql_like(path) + "/%")
+  end
+
+  def contains_other_models?
+    contained_models.exists?
+  end
+
   private
 
   def create_folder_if_necessary(folder)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -10,6 +10,8 @@ class Model < ApplicationRecord
   has_many :links, as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
+  before_update :move_files
+
   default_scope { order(:name) }
 
   acts_as_taggable_on :tags
@@ -49,5 +51,22 @@ class Model < ApplicationRecord
     end
     reload
     destroy
+  end
+
+  private
+
+  def create_folder_if_necessary(folder)
+    return if Dir.exist?(folder)
+    create_folder_if_necessary(File.dirname(folder))
+    Dir.mkdir(folder)
+  end
+
+  def move_files
+    if path_changed?
+      old_path = File.join(library.path, path_was)
+      new_path = File.join(library.path, path)
+      create_folder_if_necessary(File.dirname(new_path))
+      File.rename(old_path, new_path)
+    end
   end
 end

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -32,6 +32,29 @@
 
     <%= card :secondary, "Actions" do %>
       <%= link_to "Edit Details", edit_library_model_path(@library, @model), class: "btn btn-primary" %>
+      <% unless @model.contains_other_models? %>
+        <div class="modal fade" id="confirm-move" data-bs-backdrop='static' tabindex="-1" aria-labelledby="confirmMoveLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="confirmMoveLabel">Move model files</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <div class="modal-body">
+                The folder and files that make up this model will be moved from:<br>
+                <code><%= @model.path %></code><br>
+                to<br>
+                <code><%= @model.formatted_path %></code>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <%= button_to "Move", library_model_path(@library, @model, "model[path]": @model.formatted_path), method: :patch, class: "btn btn-warning" %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <%= button_tag "Reformat Path", class: "btn btn-warning", "data-bs-toggle": "modal", "data-bs-target": "#confirm-move" %>
+      <% end %>
     <% end %>
 
     <%= card :secondary, "Sections" do %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -41,14 +41,19 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
               </div>
               <div class="modal-body">
-                The folder and files that make up this model will be moved from:<br>
-                <code><%= @model.path %></code><br>
-                to<br>
-                <code><%= @model.formatted_path %></code>
+                <p>
+                  The folder and files that make up this model will be moved from:<br>
+                  <code><%= @model.path %></code><br>
+                  to<br>
+                  <code><%= @model.formatted_path %></code>
+                </p>
+                <p>
+                  Are you sure you want to do this?
+                </p>
               </div>
               <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <%= button_to "Move", library_model_path(@library, @model, "model[path]": @model.formatted_path), method: :patch, class: "btn btn-warning" %>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No, cancel</button>
+                <%= button_to "Yes, move the files", library_model_path(@library, @model, "model[path]": @model.formatted_path), method: :patch, class: "btn btn-warning" %>
               </div>
             </div>
           </div>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -46,6 +46,19 @@
     <%= render 'tags_card', tags: @model.tags, selected: nil %>
     <%= render 'links_card', links: @model.links %>
 
+    <% if @model.contains_other_models? %>
+      <%= card :warning, "Contained Models" do %>
+        <p>
+          The model folder on disk contains other models. You may wish to merge them into this one, or move them out.
+        </p>
+        <ul>
+          <% @model.contained_models.each do |target| %>
+            <li><%= link_to target.name, library_model_path(@library, target)%></li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+
     <% unless @model.parents.empty? %>
       <%= card :danger, "Merge" do %>
         <p>


### PR DESCRIPTION
Models that don't contain others can be moved to a standardised path. That path is currently `/{tags}/{modelName}#{modelId}`, but the ability to customise it will be coming soon.