### PR TITLE
Sort tags consistently in bulk editor

### DIFF
--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -21,7 +21,7 @@
         <td><%= form.check_box "models[#{model.id}]", { data: { bulk_item:  "#{model.id}"}}%></td>
         <td><%= link_to model.name, [@library, model], title: model.path %></td>
         <td><%= number_to_percentage model.scale_factor, strip_insignificant_zeros: true %></td>
-        <td><%= render partial: 'tag', collection: model.tags.sort_by(&:taggings_count), locals: {selected: nil, model_id: model.id } %></td>
+        <td><%= render partial: 'tag', collection: model.tags.sort_by(&:name).sort_by(&:taggings_count), locals: {selected: nil, model_id: model.id } %></td>
         <td><%= link_to model.creator.name, model.creator if model.creator %></td>
         <td><code><%= model.formatted_path if model.formatted_path != model.path %></code></td>
       </tr>


### PR DESCRIPTION
Resolves #791. Tags were sorted by count, but if many were the same (e.g. 1), then they would not be sorted. Now we sort alphabetically, then by count.