### PR TITLE
Presenting and using multiple tags (also in combination with collections)

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -30,9 +30,18 @@ class LibrariesController < ApplicationController
 
     # Filter by tag?
     if params[:tag]
-      @tag = ActsAsTaggableOn::Tag.find_by(name: params[:tag])
-      @models = @models.tagged_with(@tag) if @tag
+      @tag = ActsAsTaggableOn::Tag.named_any(params[:tag])
+      @models = @models.tagged_with(params[:tag]) if params[:tag]
     end
+
+    # Filter by collection?
+    if params[:collection]
+      @collection = ActsAsTaggableOn::Tag.for_context(:collections).find(params[:collection])
+      @models = @models.tagged_with(@collection, context: :collection) if @collection
+    end
+
+    @commontags = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: {taggable: @models.except(:limit, :offset)})
+
   end
 
   def new

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -31,6 +31,10 @@ class ModelsController < ApplicationController
     if (@tag = params[:tag])
       @models = @models.tagged_with(@tag)
     end
+    if params[:collection]
+      @collection = ActsAsTaggableOn::Tag.for_context(:collections).find(params[:collection])
+      @models = @models.tagged_with(@collection, context: :collection) if @collection
+    end
   end
 
   def bulk_update

--- a/app/views/application/_model.html.erb
+++ b/app/views/application/_model.html.erb
@@ -29,9 +29,9 @@
               <%= icon "person", "Creator" %>
               <%= link_to model.creator.name, model.creator %><br/>
             <% end %>
-            <% if @collection.nil? && model.collections.count > 0 %>
+            <% if model.collections.count > 0 %>
               <%= icon "collection", "Collection" %>
-              <%= model.collections.map{ |c| link_to c.name.titleize, collection_path(c) }.join(', ').html_safe %><br/>
+              <%= model.collections.map{ |c| link_to c.name.titleize, [model.library, collection: c.id] }.join(', ').html_safe %><br/>
             <% end %>
             <% if @library.nil? && model.library %>
               <%= icon "box-seam", "Library" %>

--- a/app/views/application/_tag.html.erb
+++ b/app/views/application/_tag.html.erb
@@ -1,5 +1,7 @@
-<% if (tag == selected) %>
-  <%=link_to tag.name, @library, {class: "badge rounded-pill bg-success tag", data: {bulk_item_tags: "#{model_id}"} } %>
+<% if ([*selected].include?(tag)) %>
+  <%=link_to tag.name, [@library, tag: [*params[:tag]] - [tag.name],collection: [*params[:collection]]], {class: "badge rounded-pill bg-success tag", data: {bulk_item_tags: "#{model_id}"} } %>
+<% elsif  defined?(commontags) && commontags.include?(tag) %>
+  <%=link_to tag.name, [@library, tag: [*params[:tag]] + [tag.name],collection: [*params[:collection]]], {class: "badge rounded-pill bg-primary tag", data: {bulk_item_tags: "#{model_id}"}} %>
 <% else %>
-  <%=link_to tag.name, [@library, tag: tag.name], {class: "badge rounded-pill bg-secondary tag", data: {bulk_item_tags: "#{model_id}"}} %>
+  <%=link_to tag.name, [@library, tag: [*params[:tag]] + [tag.name],collection: [*params[:collection]]], {class: "badge rounded-pill bg-secondary tag", data: {bulk_item_tags: "#{model_id}"}} %>
 <% end %>

--- a/app/views/application/_tags_card.html.erb
+++ b/app/views/application/_tags_card.html.erb
@@ -1,5 +1,5 @@
 <% unless tags.empty? %>
   <%= card :secondary, "Tags" do %>
-    <%= render partial: 'tag', collection: tags, locals: {selected: selected, model_id: ""} %>
+    <%= render partial: 'tag', collection: tags, locals: {commontags: commontags, tags: tags, selected: selected, model_id: ""} %>
   <% end %>
 <% end %>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -17,7 +17,8 @@
       <h5 class="card-title"><%= collection.name.titleize %></h5>
       <p class="card-text"><%= pluralize Model.tagged_with(collection, context: :collection).count, "model" %></p>
       <div>
-        <%= link_to "Open", collection_path(collection), {class: "btn btn-primary btn-sm"} %>
+        <%= icon "collection", "Collection" %>
+        <%= link_to collection.name.titleize, [model.library, collection: collection.id] %>
       </div>
     </div>
   </div>

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -24,10 +24,9 @@
 
     <%= card :secondary, "Actions" do %>
       <%= link_to 'Delete', @library, method: :delete, data: {confirm: "Are you sure? Your files will not be affected."}, class: "btn btn-danger mb-3 me-3" %>
-      <%= link_to "Bulk Edit", edit_library_models_path(@library, tag: @tag&.name), class: 'btn btn-secondary mb-3 me-3' %>
+      <%= link_to "Bulk Edit", edit_library_models_path(@library, tag: @tag?@tag.map { |t| t.name}:@tag, collection: @collection), class: 'btn btn-secondary mb-3 me-3' %>
     <% end %>
-
-    <%= render 'tags_card', tags: @tags, selected: @tag %>
+    <%= render 'tags_card', tags: @tags, selected: @tag, commontags: @commontags %>
 
   </div>
 </div>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -87,7 +87,7 @@
       </ul>
     <% end %>
 
-    <%= render 'tags_card', tags: @model.tags.sort_by(&:taggings_count), selected: nil %>
+    <%= render 'tags_card', tags: @model.tags.sort_by(&:taggings_count), selected: [], commontags: [] %>
     <%= render 'links_card', links: @model.links %>
 
     <% if @model.contains_other_models? %>


### PR DESCRIPTION
Collections "Opened" through libraries.  
In libraries a combination of collections and tags can be chosen to be anded together to narrow down choices.   
As tags are chosen, the tags that do not have commonality are greyed out.

This modifies bulk editor for collections as a partial fix to one of the elements of #785 

If you want to see the changes in action, image at: 
ghcr.io/ksuquix/van_dam:0.40.0-multitag  