### PR TITLE
Added setting to make auto-tagging on directory name optional

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -13,6 +13,7 @@ class SettingsController < ApplicationController
     end
     if current_user.admin? && params[:model_tags]
       SiteSettings.model_tags_filter_stop_words = params[:model_tags][:filter_stop_words] == "1"
+      SiteSettings.model_tags_tag_model_directory_name = params[:model_tags][:tag_model_directory_name] == "1"
       SiteSettings.model_tags_stop_words_locale = params[:model_tags][:stop_words_locale]
       SiteSettings.model_tags_custom_stop_words = params[:model_tags][:custom_stop_words].split
       SiteSettings.model_tags_auto_tag_new = params[:model_tags][:auto_tag_new]

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -21,8 +21,14 @@ class Model < ApplicationRecord
   acts_as_taggable_on :tags, :collections
 
   def autogenerate_tags_from_path!
-    tags = File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 }
+    tags = []
 
+    # Auto-tag based on model directory name:
+    if SiteSettings.model_tags_tag_model_directory_name
+      tags = File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 }
+    end
+
+    # (optional) stopwords to remove from auto tagging
     if SiteSettings.model_tags_filter_stop_words
       @filter ||= Stopwords::Snowball::Filter.new(SiteSettings.model_tags_stop_words_locale, SiteSettings.model_tags_custom_stop_words)
       tags = @filter.filter(tags)

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -3,6 +3,7 @@ class SiteSettings < RailsSettings::Base
   cache_prefix { "v1" }
 
   field :model_tags_filter_stop_words, type: :boolean, default: true
+  field :model_tags_tag_model_directory_name, type: :boolean, default: true
   field :model_tags_stop_words_locale, type: :string, default: "en"
   field :model_tags_custom_stop_words, type: :array, default: Rails.configuration.formats.flatten(2).select { |x| x.is_a?(String) }
   field :model_tags_auto_tag_new, type: :string, default: "!new"

--- a/app/views/settings/_tag_settings.html.erb
+++ b/app/views/settings/_tag_settings.html.erb
@@ -11,6 +11,12 @@
       </div>
     </div>
     <div class="row mb-2">
+      <%= form.label "Tag keywords from model directory", for: "model_tags[tag_model_directory_name]", class: "col-sm-4 col-form-label"%>
+      <div class="col-sm-8 form-check form-switch">
+        <%= form.check_box "model_tags[tag_model_directory_name]", checked: SiteSettings.model_tags_tag_model_directory_name, class: "form-check-input" %>
+      </div>
+    </div>
+    <div class="row mb-2">
       <%= form.label "Filter out stop words", for: "model_tags[filter_stop_words]", class: "col-sm-4 col-form-label"%>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "model_tags[filter_stop_words]", checked: SiteSettings.model_tags_filter_stop_words, class: "form-check-input" %>


### PR DESCRIPTION
This adds a setting that can be used to turn of the auto import of tags.  This is useful if the files have a lot of junk that is difficult to filter out with stop words, or if your tagging scheme is not related to the base directory names.