### PR TITLE
Add ActiveAdmin for tags & collections

### DIFF
--- a/app/admin/collections.rb
+++ b/app/admin/collections.rb
@@ -1,4 +1,4 @@
-ActiveAdmin.register ActsAsTaggableOn::Tag, as: 'Collections' do
+ActiveAdmin.register ActsAsTaggableOn::Tag, as: "Collections" do
   controller do
     def scoped_collection
       end_of_association_chain.for_context(:collections)

--- a/app/admin/collections.rb
+++ b/app/admin/collections.rb
@@ -1,0 +1,8 @@
+ActiveAdmin.register ActsAsTaggableOn::Tag, as: 'Collections' do
+  controller do
+    def scoped_collection
+      end_of_association_chain.for_context(:collections)
+    end
+  end
+  permit_params :name
+end

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -1,4 +1,4 @@
-ActiveAdmin.register ActsAsTaggableOn::Tag, as: 'Tag' do
+ActiveAdmin.register ActsAsTaggableOn::Tag, as: "Tags" do
   controller do
     def scoped_collection
       end_of_association_chain.for_context(:tags)

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -1,0 +1,8 @@
+ActiveAdmin.register ActsAsTaggableOn::Tag, as: 'Tag' do
+  controller do
+    def scoped_collection
+      end_of_association_chain.for_context(:tags)
+    end
+  end
+  permit_params :name
+end


### PR DESCRIPTION
Adds Tags/Collections to advanced administration to have the ability to fix systematic mistakes and/or change all instances of a tag at once.