### PR TITLE
Added notes/excerpts to models/creators/model_files

### DIFF
--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -60,6 +60,8 @@ class CreatorsController < ApplicationController
   def creator_params
     params.require(:creator).permit([
       :name,
+      :excerpt,
+      :notes,
       links_attributes: [:id, :url, :_destroy]
     ])
   end

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -70,6 +70,8 @@ class ModelFilesController < ApplicationController
     params.require(:model_file).permit([
       :printed,
       :presupported,
+      :notes,
+      :excerpt,
       :y_up
     ])
   end

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -80,6 +80,8 @@ class ModelsController < ApplicationController
       :creator_id,
       :library_id,
       :name,
+      :excerpt,
+      :notes,
       :scale_factor,
       :organize,
       collection_list: [],

--- a/app/views/application/_model.html.erb
+++ b/app/views/application/_model.html.erb
@@ -39,6 +39,9 @@
               <%= icon "box-seam", "Library" %>
               <%= link_to model.library.name, model.library %><br/>
             <% end %>
+            <% if model.excerpt %>
+              <p class="card-text"><%= sanitize model.excerpt %></p>
+            <% end %>
           </small>
         </div>
       </div>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -3,6 +3,9 @@
     <div class="card-body">
       <h5 class="card-title"><%= creator.name %></h5>
       <p class="card-text"><%= pluralize creator.models.count, "model" %></p>
+      <% if creator.excerpt %>
+        <p class="card-text"><%= sanitize creator.excerpt %></p>
+      <% end %>
       <%= link_to "Details", creator, {class: "btn btn-primary"} %>
     </div>
   </div>

--- a/app/views/creators/_form.html.erb
+++ b/app/views/creators/_form.html.erb
@@ -7,6 +7,16 @@
 
     <%= render 'links_form', :form => form %>
 
-    <%= form.submit "Save", class: "btn btn-primary" %>
+    <div class="row mb-3 input-group">
+      <%= form.label :excerpt, class: "col-sm-2 col-form-label" %>
+      <%= form.text_area :excerpt, class: "form-control col-auto" %>
+    </div>
+
+    <div class="row mb-3 input-group">
+      <%= form.label :notes, class: "col-sm-2 col-form-label" %>
+      <%= form.text_area :notes, class: "form-control col-auto" %>
+    </div>
+
+  <%= form.submit "Save", class: "btn btn-primary" %>
   </form>
 <% end %>

--- a/app/views/creators/show.html.erb
+++ b/app/views/creators/show.html.erb
@@ -23,5 +23,9 @@
       <%= link_to 'Delete', @creator, method: :delete, data: {confirm: "Are you sure?"}, class: "btn btn-danger" %>
     <% end if @creator%>
 
+    <%= card(:secondary, 'Notes') do %>
+      <p class="card-text"><%= sanitize @creator.notes %></p>
+    <% end if @creator.notes %>
+
   </div>
 </div>

--- a/app/views/model_files/_form.html.erb
+++ b/app/views/model_files/_form.html.erb
@@ -11,5 +11,16 @@
     <%= form.check_box :y_up, class: 'form-check-input' %>
     <label class="form-check-label" for="y_up">Y Up</label>
   </div>
+
+  <div class="row mb-3 input-group">
+    <%= form.label :excerpt, class: "col-sm-2 col-form-label" %>
+    <%= form.text_area :excerpt, class: "form-control col-auto" %>
+  </div>
+
+  <div class="row mb-3 input-group">
+    <%= form.label :notes, class: "col-sm-2 col-form-label" %>
+    <%= form.text_area :notes, class: "form-control col-auto" %>
+  </div>
+  
   <%= form.submit "Update", class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -29,5 +29,9 @@
       <%= link_to "#{icon('trash', 'Delete')} Delete".html_safe, library_model_model_file_path(@library, @model, @file, @file.file_format.to_sym), {method: "delete", data: {confirm: "Are you sure you want to remove this file from your filesystem?"}, class: "btn btn-danger"} %>
     <% end %>
 
+    <%= card(:secondary, 'Notes') do %>
+      <p class="card-text"><%= sanitize @file.notes %></p>
+    <% end if @file.notes %>
+
   </div>
 </div>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -10,6 +10,9 @@
     <div class="card-body">
       <h5 class="card-title"><%= file.name %></h5>
       <%= form_with model: [@library, @model] do |form| %>
+        <% if file.excerpt %>
+          <p class="card-text"><%= sanitize file.excerpt %></p>
+        <% end %>
         <%= link_to "Details", library_model_model_file_path(@library, @model, file), {class: "btn btn-primary"} %>
         <%= link_to icon('cloud-download', 'Download'), library_model_model_file_path(@library, @model, file, file.file_format.to_sym), {class: "btn btn-secondary"} %>
         <%= form.hidden_field :preview_file_id, value: file.id %>

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -44,6 +44,16 @@
 
     <%= render 'links_form', :form => form %>
 
+    <div class="row mb-3 input-group">
+      <%= form.label :excerpt, class: "col-sm-2 col-form-label" %>
+      <%= form.text_area :excerpt, class: "form-control col-auto" %>
+    </div>
+
+    <div class="row mb-3 input-group">
+      <%= form.label :notes, class: "col-sm-2 col-form-label" %>
+      <%= form.text_area :notes, class: "form-control col-auto" %>
+    </div>
+    
     <%= form.submit "Save", class: "btn btn-primary" %>
   </form>
 <% end %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -78,6 +78,10 @@
       <% end %>
     <% end %>
 
+    <%= card(:secondary, 'Notes') do %>
+      <p class="card-text"><%= sanitize @model.notes %></p>
+    <% end if @model.notes %>
+
     <%= card :secondary, "Sections" do %>
       <a href="#files">Files</a>
       <ul>

--- a/db/migrate/20230202210000_add_notes_excerpt_to_models.rb
+++ b/db/migrate/20230202210000_add_notes_excerpt_to_models.rb
@@ -1,0 +1,6 @@
+class AddNotesExcerptToModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :models, :notes, :text
+    add_column :models, :excerpt, :text
+  end
+end

--- a/db/migrate/20230202210001_add_notes_excerpt_to_creators.rb
+++ b/db/migrate/20230202210001_add_notes_excerpt_to_creators.rb
@@ -1,0 +1,6 @@
+class AddNotesExcerptToCreators < ActiveRecord::Migration[7.0]
+  def change
+    add_column :creators, :notes, :text
+    add_column :creators, :excerpt, :text
+  end
+end

--- a/db/migrate/20230203150000_add_notes_excerpt_to_model_files.rb
+++ b/db/migrate/20230203150000_add_notes_excerpt_to_model_files.rb
@@ -1,0 +1,6 @@
+class AddNotesExcerptToModelFiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :model_files, :notes, :text
+    add_column :model_files, :excerpt, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_210001) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_03_150000) do
   create_table "creators", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -61,6 +61,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_210001) do
     t.boolean "printed", default: false
     t.boolean "y_up", default: false, null: false
     t.string "digest"
+    t.text "notes"
+    t.text "excerpt"
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["model_id"], name: "index_model_files_on_model_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_10_001132) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_210001) do
   create_table "creators", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "notes"
+    t.text "excerpt"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
@@ -56,9 +58,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_10_001132) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "presupported", default: false
+    t.boolean "printed", default: false
     t.boolean "y_up", default: false, null: false
     t.string "digest"
-    t.boolean "printed"
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["model_id"], name: "index_model_files_on_model_id"
   end
@@ -72,6 +74,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_10_001132) do
     t.integer "preview_file_id"
     t.integer "creator_id"
     t.decimal "scale_factor", default: "100.0", null: false
+    t.text "notes"
+    t.text "excerpt"
     t.index ["creator_id"], name: "index_models_on_creator_id"
     t.index ["library_id"], name: "index_models_on_library_id"
     t.index ["preview_file_id"], name: "index_models_on_preview_file_id"


### PR DESCRIPTION
Two fields:
Notes:  appears on a side panel on the appropriate page.

Excerpt: A note that appears when listing that type (e.g.  model excerpts show when listing all models in a library)

Both allow limited HTML so you can do some basic styling, etc.
