### PR TITLE
if scale_factor doesn't exist on objects, don't break when removing it

### DIFF
--- a/db/data/20230221174212_move_scale_factor_into_note.rb
+++ b/db/data/20230221174212_move_scale_factor_into_note.rb
@@ -3,7 +3,7 @@
 class MoveScaleFactorIntoNote < ActiveRecord::Migration[7.0]
   def up
     Model.all.each do |model|
-      if model.scale_factor != 100
+      if defined?(model.scale_factor) && (model.scale_factor != 100)
         model.update!(notes: [
           model.notes,
           "Scale factor: #{model.scale_factor}%"


### PR DESCRIPTION
This happened at least on my local install.