### PR TITLE
Add curly braces around path tokens

### DIFF
--- a/app/models/concerns/path_builder.rb
+++ b/app/models/concerns/path_builder.rb
@@ -5,11 +5,11 @@ module PathBuilder
     formatted_path_out = []
     SiteSettings.model_path_prefix_template.split("/").each { |p|
       case p
-      when "tags"
+      when "{tags}"
         formatted_path_out.push(tags.order(taggings_count: :desc).map(&:to_s).map(&:parameterize))
-      when "creator"
+      when "{creator}"
         formatted_path_out.push(creator ? creator.name : "unset-creator")
-      when "collection"
+      when "{collection}"
         formatted_path_out.push((collections.count > 0) ? collections.map { |c| c.name } : "unset-collection")
       else
         formatted_path_out.push("bad-formatted-path-element")

--- a/app/models/concerns/path_parser.rb
+++ b/app/models/concerns/path_parser.rb
@@ -23,17 +23,17 @@ module PathParser
       creatornew = ""
       collectionnew = ""
       tags = []
-      while !templatechunks.empty? && !filepaths.empty? && !(templatechunks.length == 1 && templatechunks[0] == "tags")
-        if templatechunks[0] == "creator"
+      while !templatechunks.empty? && !filepaths.empty? && !(templatechunks.length == 1 && templatechunks[0] == "{tags}")
+        if templatechunks[0] == "{creator}"
           creatornew = filepaths.shift
           templatechunks.shift
-        elsif templatechunks[0] == "collection"
+        elsif templatechunks[0] == "{collection}"
           collectionnew = filepaths.shift
           templatechunks.shift
-        elsif templatechunks[-1] == "creator"
+        elsif templatechunks[-1] == "{creator}"
           creatornew = filepaths.pop
           templatechunks.pop
-        elsif templatechunks[-1] == "collection"
+        elsif templatechunks[-1] == "{collection}"
           collectionnew = filepaths.pop
           templatechunks.pop
         else
@@ -41,7 +41,7 @@ module PathParser
           templatechunks.shift
         end
       end
-      if templatechunks.length == 1 && templatechunks[0] == "tags"
+      if templatechunks.length == 1 && templatechunks[0] == "{tags}"
         tags = filepaths
       end
       unless tags.empty?

--- a/spec/models/concerns/path_builder_spec.rb
+++ b/spec/models/concerns/path_builder_spec.rb
@@ -11,27 +11,27 @@ RSpec.describe PathBuilder do
     }
 
     it "includes creator if set" do
-      SiteSettings.model_path_prefix_template = "creator"
+      SiteSettings.model_path_prefix_template = "{creator}"
       expect(model.formatted_path).to eq "/Bruce Wayne/batarang#1"
     end
 
     it "includes tags if set" do
-      SiteSettings.model_path_prefix_template = "tags"
+      SiteSettings.model_path_prefix_template = "{tags}"
       expect(model.formatted_path).to eq "/bat/weapon/batarang#1"
     end
 
     it "includes collection if set" do
-      SiteSettings.model_path_prefix_template = "collection"
+      SiteSettings.model_path_prefix_template = "{collection}"
       expect(model.formatted_path).to eq "/gadgets/batarang#1"
     end
 
     it "includes multiple metadata types if set" do
-      SiteSettings.model_path_prefix_template = "collection/creator/tags"
+      SiteSettings.model_path_prefix_template = "{collection}/{creator}/{tags}"
       expect(model.formatted_path).to eq "/gadgets/Bruce Wayne/bat/weapon/batarang#1"
     end
 
     it "includes error path for unknown prefixes" do
-      SiteSettings.model_path_prefix_template = "bad"
+      SiteSettings.model_path_prefix_template = "{bad}"
       expect(model.formatted_path).to eq "/bad-formatted-path-element/batarang#1"
     end
   end
@@ -40,17 +40,17 @@ RSpec.describe PathBuilder do
     let(:model) { create(:model, name: "Batarang") }
 
     it "includes creator error if set" do
-      SiteSettings.model_path_prefix_template = "creator"
+      SiteSettings.model_path_prefix_template = "{creator}"
       expect(model.formatted_path).to eq "/unset-creator/batarang#1"
     end
 
     it "handles zero tags" do
-      SiteSettings.model_path_prefix_template = "tags"
+      SiteSettings.model_path_prefix_template = "{tags}"
       expect(model.formatted_path).to eq "/batarang#1"
     end
 
     it "includes collection error if set" do
-      SiteSettings.model_path_prefix_template = "collection"
+      SiteSettings.model_path_prefix_template = "{collection}"
       expect(model.formatted_path).to eq "/unset-collection/batarang#1"
     end
   end

--- a/spec/models/concerns/path_parser_spec.rb
+++ b/spec/models/concerns/path_parser_spec.rb
@@ -85,25 +85,25 @@ RSpec.describe PathParser do
     end
 
     it "parses tags" do
-      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("tags")
+      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("{tags}")
       model.autogenerate_creator_from_prefix_template!
       expect(model.tag_list).to eq ["library1", "stuff", "tags", "are", "greedy"]
     end
 
     it "parses creator" do
-      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("creator")
+      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("{creator}")
       model.autogenerate_creator_from_prefix_template!
       expect(model.creator.name).to eq "library1"
     end
 
     it "parses collection" do
-      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("collection")
+      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("{collection}")
       model.autogenerate_creator_from_prefix_template!
       expect(model.collection_list).to eq ["library1"]
     end
 
     it "parses everything at once" do
-      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("creator/collection/tags")
+      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("{creator}/{collection}/{tags}")
       model.autogenerate_creator_from_prefix_template!
       expect(model.creator.name).to eq "library1"
       expect(model.collection_list).to eq ["stuff"]
@@ -111,7 +111,7 @@ RSpec.describe PathParser do
     end
 
     it "ignores extra path components" do
-      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("creator")
+      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("{creator}")
       model.autogenerate_creator_from_prefix_template!
       expect(model.creator.name).to eq "library1"
       expect(model.collection_list).to eq []
@@ -130,7 +130,7 @@ RSpec.describe PathParser do
       allow(SiteSettings).to receive(:model_tags_stop_words_locale).and_return("en")
       allow(SiteSettings).to receive(:model_tags_filter_stop_words).and_return(true)
       allow(SiteSettings).to receive(:model_tags_custom_stop_words).and_return(["stuff"])
-      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("tags")
+      allow(SiteSettings).to receive(:model_path_prefix_template).and_return("{tags}")
       model.autogenerate_creator_from_prefix_template!
       expect(model.tag_list).to eq ["library1", "tags", "greedy"]
     end


### PR DESCRIPTION
To make it easier to extend, and include non-token content in path parsing, I've added curly braces around the tokens.