### PR TITLE
Changed tag sorting in bulk edit to reflect tags_cloud_sorting setting

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -22,7 +22,7 @@ class ModelsController < ApplicationController
     when "alphabetical"
       @tags.sort_by(&:name)
     else
-      @tags.sort_by(&:taggings_count).reverse
+      @tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse
     end
 
     process_filters

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -19,11 +19,11 @@
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= render partial: 'tag', 
           collection: (SiteSettings.model_tags_cloud_sorting=="alphabetical") ?
-            model.collections.sort_by(&:name) : model.collections.sort_by(&:taggings_count).reverse,
+            model.collections.sort_by(&:name) : model.collections.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
           locals: {state: :normal, model_id: model.id } %></td>
         <td><%= render partial: 'tag', 
           collection: (SiteSettings.model_tags_cloud_sorting=="alphabetical") ?
-            model.tags.sort_by(&:name) : model.tags.sort_by(&:taggings_count).reverse,
+            model.tags.sort_by(&:name) : model.tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
             locals: {state: :normal, model_id: model.id } %></td>
         <td><%= link_to model.creator.name, model.creator if model.creator %></td>
         <td><code><%= model.formatted_path if model.formatted_path != model.path %></code></td>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -17,8 +17,14 @@
       <tr>
         <td><%= form.check_box "models[#{model.id}]", { data: { bulk_item:  "#{model.id}"}}%></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
-        <td><%= render partial: 'tag', collection: model.collections.sort_by(&:name).sort_by(&:taggings_count), locals: {state: :normal, model_id: model.id } %></td>
-        <td><%= render partial: 'tag', collection: model.tags.sort_by(&:name).sort_by(&:taggings_count), locals: {state: :normal, model_id: model.id } %></td>
+        <td><%= render partial: 'tag', 
+          collection: (SiteSettings.model_tags_cloud_sorting=="alphabetical") ?
+            model.collections.sort_by(&:name) : model.collections.sort_by(&:taggings_count).reverse,
+          locals: {state: :normal, model_id: model.id } %></td>
+        <td><%= render partial: 'tag', 
+          collection: (SiteSettings.model_tags_cloud_sorting=="alphabetical") ?
+            model.tags.sort_by(&:name) : model.tags.sort_by(&:taggings_count).reverse,
+            locals: {state: :normal, model_id: model.id } %></td>
         <td><%= link_to model.creator.name, model.creator if model.creator %></td>
         <td><code><%= model.formatted_path if model.formatted_path != model.path %></code></td>
       </tr>


### PR DESCRIPTION
Related to closed issue #791, this adjusts the sorting to alpha or frequency depending on site owner's desire