### PR TITLE
Tag keypair collapsible display

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -14,6 +14,7 @@ class SettingsController < ApplicationController
     if current_user.admin? && params[:model_tags]
       SiteSettings.model_tags_cloud_threshhold = params[:model_tags][:cloud_threshhold]
       SiteSettings.model_tags_cloud_heatmap = params[:model_tags][:cloud_heatmap] == "1"
+      SiteSettings.model_tags_cloud_keypair = params[:model_tags][:cloud_keypair] == "1"
       SiteSettings.model_tags_cloud_sorting = params[:model_tags][:cloud_sorting]
       SiteSettings.model_tags_filter_stop_words = params[:model_tags][:filter_stop_words] == "1"
       SiteSettings.model_tags_tag_model_directory_name = params[:model_tags][:tag_model_directory_name] == "1"

--- a/app/javascript/application.ts
+++ b/app/javascript/application.ts
@@ -13,5 +13,6 @@ import '@nathanvda/cocoon'
 import 'src/preview'
 import 'src/bulk_edit'
 import 'src/model_edit'
+import 'src/tag'
 
 Rails.start()

--- a/app/javascript/src/tag.ts
+++ b/app/javascript/src/tag.ts
@@ -17,7 +17,7 @@ $(document).ready(
       window.localStorage.setItem(`details-${id}`, isOpen)
     })
     for (let i = 0; i < localStorage.length; i++) {
-      setDetailOpenStatus(localStorage.key(i))
+      setDetailOpenStatus(localStorage.key(i) ?? '')
     }
   }
 )

--- a/app/javascript/src/tag.ts
+++ b/app/javascript/src/tag.ts
@@ -1,0 +1,23 @@
+function setDetailOpenStatus (item: string): void {
+  if (item.includes('details-')) {
+    const id = item.split('details-')[1]
+    const status = window.localStorage.getItem(item)
+    if (status === 'open') {
+      $(`#${id}`).attr('open', 'open')
+    }
+  }
+}
+
+$(document).ready(
+  function () {
+    $('details').on('toggle', function (event): void {
+      const id = $(this).attr('id') ?? ''
+      const isOpen = $(this).attr('open') ?? ''
+      console.log(id, isOpen)
+      window.localStorage.setItem(`details-${id}`, isOpen)
+    })
+    for (let i = 0; i < localStorage.length; i++) {
+      setDetailOpenStatus(localStorage.key(i))
+    }
+  }
+)

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -4,6 +4,7 @@ class SiteSettings < RailsSettings::Base
 
   field :model_tags_cloud_threshhold, type: :integer, default: 0
   field :model_tags_cloud_heatmap, type: :boolean, default: true
+  field :model_tags_cloud_keypair, type: :boolean, default: true
   field :model_tags_cloud_sorting, type: :string, default: "frequency"
   field :model_tags_filter_stop_words, type: :boolean, default: true
   field :model_tags_tag_model_directory_name, type: :boolean, default: true

--- a/app/views/application/_tag.html.erb
+++ b/app/views/application/_tag.html.erb
@@ -1,7 +1,8 @@
 <%- filters = @filters || {} %>
 <%- filters[:tag] ||= [] %>
 <%=
-  link_to SiteSettings.model_tags_cloud_heatmap ? "#{tag.name} (#{Model.tagged_with(tag.name).count})" : tag.name,
+  name = SiteSettings.model_tags_cloud_keypair ? tag.name.gsub(/^.*:/,"") : tag.name
+  link_to SiteSettings.model_tags_cloud_heatmap ? "#{name} (#{Model.tagged_with(tag.name).count})" : name,
     models_path(filters.merge(tag: filters[:tag] | [tag.name])),
     {
       class: "badge rounded-pill #{tag_class(state)} tag",

--- a/app/views/application/_tags_card.html.erb
+++ b/app/views/application/_tags_card.html.erb
@@ -10,7 +10,7 @@
     <ul class="list-unstyled">
       <% tiers.each do |tier| %>
         <%= content_tag(:li, content_tag(:details,
-          content_tag(:summary,tier)+tiertags.select{|obj| obj.name.include?("#{tier}:")}
+          content_tag(:summary,tier)+tiertags.select{|obj| obj.name.match?("^#{tier}:")}
             .map{|tag| render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)}}.join.html_safe,open: true)) %>
       <% end %>
     </ul>

--- a/app/views/application/_tags_card.html.erb
+++ b/app/views/application/_tags_card.html.erb
@@ -1,18 +1,23 @@
 <% unless tags.empty? %>
   <%= card :secondary, "Tags" do %>
-    <% plaintags = tags.select{|obj| !obj.name.include?(":") } %>
-    <% tiertags = tags.select{|obj| obj.name.include?(":") } %>
-    <% tiers = tiertags.map(&:name).map {|tag| tag.split(":").first}.uniq.sort %>
-    <% tags = plaintags %>
+    <% if SiteSettings.model_tags_cloud_keypair %>
+      <% plaintags = tags.select{|obj| !obj.name.include?(":") } %>
+      <% tiertags = tags.select{|obj| obj.name.include?(":") } %>
+      <% tiers = tiertags.map(&:name).map {|tag| tag.split(":").first}.uniq.sort %>
+      <% tags = plaintags %>
+    <% end %>
     <% tags.each do |tag| %>
       <%= render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)} %>
     <% end %>
-    <ul class="list-unstyled">
-      <% tiers.each do |tier| %>
-        <%= content_tag(:li, content_tag(:details,
-          content_tag(:summary,tier)+tiertags.select{|obj| obj.name.match?("^#{tier}:")}
-            .map{|tag| render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)}}.join.html_safe,open: true)) %>
-      <% end %>
-    </ul>
+    <% if SiteSettings.model_tags_cloud_keypair %>
+      <ul class="list-unstyled">
+        <% tiers.each do |tier| %>
+          <%= content_tag(:li, content_tag(:details,
+            content_tag(:summary,tier)+tiertags.select{|obj| obj.name.match?("^#{tier}:")}
+              .map{|tag| render partial: 'tag', locals: 
+              {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)}}.join.html_safe,id: tier)) %>
+        <% end %>
+      </ul>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/application/_tags_card.html.erb
+++ b/app/views/application/_tags_card.html.erb
@@ -1,7 +1,18 @@
 <% unless tags.empty? %>
   <%= card :secondary, "Tags" do %>
+    <% plaintags = tags.select{|obj| !obj.name.include?(":") } %>
+    <% tiertags = tags.select{|obj| obj.name.include?(":") } %>
+    <% tiers = tiertags.map(&:name).map {|tag| tag.split(":").first}.uniq.sort %>
+    <% tags = plaintags %>
     <% tags.each do |tag| %>
       <%= render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)} %>
     <% end %>
+    <ul class="list-unstyled">
+      <% tiers.each do |tier| %>
+        <%= content_tag(:li, content_tag(:details,
+          content_tag(:summary,tier)+tiertags.select{|obj| obj.name.include?("#{tier}:")}
+            .map{|tag| render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)}}.join.html_safe,open: true)) %>
+      <% end %>
+    </ul>
   <% end %>
 <% end %>

--- a/app/views/settings/_tag_settings.html.erb
+++ b/app/views/settings/_tag_settings.html.erb
@@ -71,5 +71,11 @@
         <%= form.select "model_tags[cloud_sorting]", ["frequency","alphabetical"], selected: SiteSettings.model_tags_cloud_sorting, class: "form-select" %>
       </div>
     </div>
+    <div class="row mb-2">
+      <%= form.label "Use delimiter to represent keypairs tag cloud", for: "model_tags[cloud_keypair]", class: "col-sm-4 col-form-label"%>
+      <div class="col-sm-8 form-check form-switch">
+        <%= form.check_box "model_tags[cloud_keypair]", checked: SiteSettings.model_tags_cloud_keypair, class: "form-check-input" %>
+      </div>
+    </div>    
   </div>
 </div>


### PR DESCRIPTION
Displays (if not turned off) tags like: 
  color:red, color:blue, color:green
as:
  color:
    red, blue, green
In the tag cloud in a collapsible way.   As the cloud is collapsed/expanded, page loads will remember the state of the tree.

Still to be done to consider this all complete: 
* Per-library overrides for different behavior in different libraries.
* configurable delimiter
