### PR TITLE
move_files is executed twice per model on bulk update.  

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -71,12 +71,15 @@ class Model < ApplicationRecord
     if (library_id_changed? || ActiveModel::Type::Boolean.new.cast(organize)) && !contains_other_models?
       old_path = File.join(Library.find(library_id_was).path, path)
       new_path = File.join(library.path, formatted_path)
-      create_folder_if_necessary(File.dirname(new_path))
-      if !File.exist?(new_path)
-        File.rename(old_path, new_path)
-        self.path = formatted_path
-      else
-        problems.create(category: :destination_exists)
+      # This test added because move_files is somehow getting called twice on bulk_update
+      if(old_path != new_path)
+        create_folder_if_necessary(File.dirname(new_path))
+        if !File.exist?(new_path)
+          File.rename(old_path, new_path)
+          self.path = formatted_path
+        else
+          problems.create(category: :destination_exists)
+        end
       end
     end
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -72,7 +72,7 @@ class Model < ApplicationRecord
       old_path = File.join(Library.find(library_id_was).path, path)
       new_path = File.join(library.path, formatted_path)
       # This test added because move_files is somehow getting called twice on bulk_update
-      if(old_path != new_path)
+      if old_path != new_path
         create_folder_if_necessary(File.dirname(new_path))
         if !File.exist?(new_path)
           File.rename(old_path, new_path)


### PR DESCRIPTION
make the move only happen if it hasn't already

Closes #1059 