### PR TITLE
RAR, ZIP, 7Z, GZ, and BZIP2 support for file uploading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.1-alpine AS build
 
-RUN apk add --no-cache tzdata alpine-sdk postgresql-dev nodejs yarn xz
+RUN apk add --no-cache tzdata alpine-sdk postgresql-dev nodejs yarn xz libarchive
 RUN gem install foreman
 
 ARG VAN_DAM_GIT_REF

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "redis", "~> 5.0"
 gem "dotenv-rails", "~> 2.8"
 gem "acts-as-taggable-on", "~> 9.0"
 
-gem "rubyzip", "~> 2.3"
+gem "ffi-libarchive", "~> 1.1"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    ffi-libarchive (1.1.3)
+      ffi (~> 1.0)
     formatador (0.3.0)
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
@@ -362,7 +364,6 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -441,6 +442,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.8)
   factory_bot
   faker (~> 3.1)
+  ffi-libarchive (~> 1.1)
   guard (~> 2.18)
   guard-rspec (~> 4.7)
   i18n-tasks (~> 1.0)
@@ -462,7 +464,6 @@ DEPENDENCIES
   rubocop-performance (~> 1.15)
   rubocop-rails
   rubocop-rspec
-  rubyzip (~> 2.3)
   sass-rails (>= 6)
   simplecov (~> 0.22.0)
   spring

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can run all the dependencies in one go using `docker-compose`:
 - Node.js 16.x
 - Yarn >= 1.22
 - Foreman or [another Procfile runner](https://github.com/ddollar/foreman#ports)
+- [libarchive](https://github.com/chef/ffi-libarchive#installation) (for upload support)
 
 ### Usage
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -33,6 +33,5 @@ class UploadsController < ApplicationController
     end
   ensure
     reader&.close
-    raise
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,5 +1,3 @@
-require "zip"
-
 class UploadsController < ApplicationController
   def create
     library = Library.find(params[:post][:library_pick])
@@ -25,14 +23,15 @@ class UploadsController < ApplicationController
   end
 
   def unzip(dest_folder_name, datafile)
+    flags = Archive::EXTRACT_PERM
+    reader = Archive::Reader.open_filename(datafile.path)
     Dir.mkdir(dest_folder_name)
-
-    Zip::File.open(datafile) do |zipfile|
-      zipfile.each do |f|
-        f_path = File.join(dest_folder_name, f.name)
-        FileUtils.mkdir_p(File.dirname(f_path))
-        zipfile.extract(f, f_path) unless File.exist?(f_path)
+    Dir.chdir(dest_folder_name) do
+      reader.each_entry do |entry|
+        reader.extract(entry, flags.to_i)
       end
     end
+  ensure
+    reader.close
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -32,6 +32,7 @@ class UploadsController < ApplicationController
       end
     end
   ensure
-    reader.close
+    reader&.close
+    raise
   end
 end

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -11,7 +11,7 @@
   <div class="row mb-3 input-group">
     <%= label :upload, 'Select File', for: 'upload', class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
-      <%= file_field 'upload', 'datafiles', {multiple: true, accept: 'application/zip'} %>
+      <%= file_field 'upload', 'datafiles', {multiple: true, accept: 'application/zip,application/x-rar-compressed,application/x-7z-compressed'} %>
     </div>
   </div>
 
@@ -25,4 +25,3 @@
   <%= submit_tag "Upload", class: 'btn btn-primary' %>
 
 <% end %>
-

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -11,7 +11,10 @@
   <div class="row mb-3 input-group">
     <%= label :upload, 'Select File', for: 'upload', class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
-      <%= file_field 'upload', 'datafiles', {multiple: true, accept: 'application/zip,application/x-rar-compressed,application/x-7z-compressed'} %>
+      <%= file_field 'upload', 'datafiles', {
+        multiple: true,
+        accept: 'application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-bzip2,application/x-bzip,application/gzip'
+      } %>
     </div>
   </div>
 


### PR DESCRIPTION
Using libarchive instead of rubyzip, we can support a ton of archive formats. libarchive is now an OS dependency, but that only matters to devs really.