### PR TITLE
Hide tags not shared with currently-selected tags in model list

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,8 @@ module ApplicationHelper
       "bg-primary"
     when :mute
       "border border-muted text-muted pe-none"
+    when :hide
+      "d-none"
     else
       "bg-secondary link-light"
     end

--- a/app/views/application/_tags_card.html.erb
+++ b/app/views/application/_tags_card.html.erb
@@ -7,17 +7,20 @@
       <% tags = plaintags %>
     <% end %>
     <% tags.each do |tag| %>
-      <%= render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)} %>
+      <%= render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :hide : :normal)} %>
     <% end %>
     <% if SiteSettings.model_tags_cloud_keypair %>
       <ul class="list-unstyled">
         <% tiers.each do |tier| %>
           <%= content_tag(:li, content_tag(:details,
             content_tag(:summary,tier)+tiertags.select{|obj| obj.name.match?("^#{tier}:")}
-              .map{|tag| render partial: 'tag', locals: 
-              {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :mute : :normal)}}.join.html_safe,id: tier)) %>
+              .map{|tag| render partial: 'tag', locals:
+              {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? :hide : :normal)}}.join.html_safe,id: tier)) %>
         <% end %>
       </ul>
+    <% end %>
+    <% if defined?(muted_tags) && !muted_tags.empty? %>
+      <p class="small"><%= pluralize(muted_tags.count, "unrelated tag") %> hidden</p>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
reduces a lot of visual clutter. I added a text note to say how many unrelated tags were hidden.