### PR TITLE
Ruby-side model loading using Mittsu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.1-alpine AS build
 
-RUN apk add --no-cache tzdata alpine-sdk postgresql-dev nodejs yarn xz libarchive
+RUN apk add --no-cache tzdata alpine-sdk postgresql-dev nodejs yarn xz libarchive glfw
 RUN gem install foreman
 
 ARG VAN_DAM_GIT_REF

--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,5 @@ gem "kaminari", "~> 1.2"
 gem "lograge", "~> 0.12.0"
 
 gem "sqlite3_ar_regexp", "~> 2.2"
+
+gem "mittsu", github: "danini-the-panini/mittsu", ref: "7f44c46"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/danini-the-panini/mittsu.git
+  revision: 7f44c468f9d6d8b5548ca933dea2d1a873ac496d
+  ref: 7f44c46
+  specs:
+    mittsu (0.4.0)
+      chunky_png
+      ffi
+      opengl-bindings
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -96,6 +106,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    chunky_png (1.4.0)
     cocoon (1.2.15)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -249,6 +260,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    opengl-bindings (1.6.13)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
@@ -460,6 +472,7 @@ DEPENDENCIES
   listen (~> 3.8)
   lograge (~> 0.12.0)
   memoist (~> 0.16.2)
+  mittsu!
   pg (~> 1.4)
   public_suffix (~> 5.0)
   puma (~> 6.2)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can run all the dependencies in one go using `docker-compose`:
    This might fail the first time it's run due to race conditions in setting up
    the database.
 
-3. Open Van DAM at http://localhost:3214
+3. Open Van DAM at <http://localhost:3214>
 
 4. Add a library
 
@@ -51,6 +51,7 @@ You can run all the dependencies in one go using `docker-compose`:
 - Yarn >= 1.22
 - Foreman or [another Procfile runner](https://github.com/ddollar/foreman#ports)
 - [libarchive](https://github.com/chef/ffi-libarchive#installation) (for upload support)
+- [glfw3](https://github.com/danini-the-panini/mittsu#installation) (for model analysis & manipulation)
 
 ### Usage
 
@@ -61,7 +62,7 @@ bundle exec rake db:migrate:with_data
 bin/dev
 ```
 
-The server will then be running at http://127.0.0.1:5000
+The server will then be running at <http://127.0.0.1:5000>
 
 ### How to run the test suite
 
@@ -71,4 +72,4 @@ The server will then be running at http://127.0.0.1:5000
 
 Built with [Rails 7](https://rubyonrails.org/),
 [Three.js](https://threejs.org/) and [Bootstrap 5](http://getbootstrap.com). Source code is open under the MIT license at
-https://github.com/floppy/van_dam.
+<https://github.com/floppy/van_dam>.

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -1,4 +1,6 @@
 class ModelFile < ApplicationRecord
+  extend Memoist
+
   belongs_to :model
   has_many :problems, as: :problematic, dependent: :destroy
 
@@ -28,7 +30,27 @@ class ModelFile < ApplicationRecord
     nil
   end
 
+  def bounding_box
+    return nil unless mesh
+    bbox = Mittsu::Box3.new.set_from_object(mesh)
+    bbox.size.to_a
+  end
+
   def remove_file
     File.delete(pathname) if File.exist?(pathname)
+  end
+
+  private
+
+  def mesh
+    loader&.new&.load(pathname)
+  end
+  memoize :mesh
+
+  def loader
+    case extension
+    when "obj"
+      Mittsu::OBJLoader
+    end
   end
 end

--- a/spec/fixtures/library/model_one/part_1.obj
+++ b/spec/fixtures/library/model_one/part_1.obj
@@ -5,9 +5,9 @@ mtllib obj.mtl
 o obj_0
 v -1 		-5 		20
 v 9 		-15 		0
-v 9 		5 		0
-v -11 		-15 		0
-v -11 		5 		0
+v 9 		0 		0
+v -1 		-15 		0
+v -1 		0 		0
 # 5 vertices
 
 g group_0_16768282
@@ -24,4 +24,3 @@ f 3 	5 	1
 # 6 faces
 
  #end of obj_0
-

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -26,4 +26,11 @@ RSpec.describe ModelFile do
     model2 = create(:model, library: library, path: "model2")
     expect(build(:model_file, model: model2, filename: "part.stl")).to be_valid
   end
+
+  it "calculates a bounding box for model" do
+    library = create(:library, path: Rails.root.join("spec/fixtures/library"))
+    model1 = create(:model, library: library, path: "model_one")
+    part = create(:model_file, model: model1, filename: "part_1.obj")
+    expect(part.bounding_box).to eq([10, 15, 20])
+  end
 end


### PR DESCRIPTION
In order to do things like #593 and other future experiments like streaming model data, we need to load the model in Ruby on the server side. This PR adds [Mittsu](https://github.com/danini-the-panini/mittsu), a Ruby 3d library heavily based on THREE.js, in order to support a number of new capabilities. It adds `ModelFile#bounding_box` to show the size of a part as a proof of concept.