### PR TITLE
Fix incorrect behaviour when moving and organising models

### DIFF
--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -16,6 +16,8 @@ class ModelScanJob < ApplicationJob
   end
 
   def perform(model)
+    # Clean up old unused problems
+    model.problems.where(category: :destination_exists).destroy_all
     # Clean out missing files
     clean_up_missing_files(model)
     # For each file in the model, create a file object

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -81,20 +81,9 @@ class Model < ApplicationRecord
     File.join(previous_library.path, previous_path)
   end
 
-  def move_files
-    if (library_id_changed? || ActiveModel::Type::Boolean.new.cast(organize)) && !contains_other_models?
-      old_path = File.join(Library.find(library_id_was).path, path)
-      new_path = File.join(library.path, formatted_path)
-      # This test added because move_files is somehow getting called twice on bulk_update
-      if old_path != new_path
-        create_folder_if_necessary(File.dirname(new_path))
-        if !File.exist?(new_path)
-          File.rename(old_path, new_path)
-          self.path = formatted_path
-        else
-          problems.create(category: :destination_exists)
-        end
-      end
-    end
+  def need_to_move_files?
+    library_id_changed? || path_changed?
+  end
+
   end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -24,7 +24,7 @@ class Model < ApplicationRecord
   validate :check_for_submodels, on: :update, if: :need_to_move_files?
   validate :destination_is_vacant, on: :update, if: :need_to_move_files?
 
-  
+  before_update :move_files, if: :need_to_move_files?
 
   def parents
     Pathname.new(path).parent.descend.filter_map do |path|
@@ -103,5 +103,9 @@ class Model < ApplicationRecord
       errors.add(:path, "already exists")
     end
   end
+
+  def move_files
+    FileUtils.mkdir_p(File.dirname(absolute_path))
+    File.rename(previous_absolute_path, absolute_path)
   end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -21,6 +21,7 @@ class Model < ApplicationRecord
 
   validates :name, presence: true
   validates :path, presence: true, uniqueness: {scope: :library}
+  validate :check_for_submodels, on: :update, if: :need_to_move_files?
 
   
 
@@ -88,6 +89,12 @@ class Model < ApplicationRecord
 
   def autoupdate_path
     self.path = formatted_path
+  end
+
+  def check_for_submodels
+    if contains_other_models?
+      errors.add(library_id_changed? ? :library : :path, "can't be changed, model contains other models")
+    end
   end
 
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -17,6 +17,7 @@ class Model < ApplicationRecord
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
   attr_accessor :organize
+  before_validation :autoupdate_path, if: :organize
 
   validates :name, presence: true
   validates :path, presence: true, uniqueness: {scope: :library}
@@ -83,6 +84,10 @@ class Model < ApplicationRecord
 
   def need_to_move_files?
     library_id_changed? || path_changed?
+  end
+
+  def autoupdate_path
+    self.path = formatted_path
   end
 
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -63,18 +63,22 @@ class Model < ApplicationRecord
     formatted_path != path
   end
 
-  private
-
-  def cannot_move_models_with_submodels
-    if (library_id_changed? || ActiveModel::Type::Boolean.new.cast(organize)) && contains_other_models?
-      errors.add(library_id_changed? ? :library : :organize, "can't move models containing other models")
-    end
+  def absolute_path
+    File.join(library.path, path)
   end
 
-  def create_folder_if_necessary(folder)
-    return if Dir.exist?(folder)
-    create_folder_if_necessary(File.dirname(folder))
-    Dir.mkdir(folder)
+  private
+
+  def previous_library
+    library_id_changed? ? Library.find(library_id_was) : library
+  end
+
+  def previous_path
+    path_changed? ? path_was : path
+  end
+
+  def previous_absolute_path
+    File.join(previous_library.path, previous_path)
   end
 
   def move_files

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -47,9 +47,9 @@ class Model < ApplicationRecord
   end
 
   def contained_models
-    Library.find(library_id_was).models.where(
+    previous_library.models.where(
       Model.arel_table[:path].matches(
-        Model.sanitize_sql_like(path) + "/%",
+        Model.sanitize_sql_like(previous_path) + "/%",
         "\\"
       )
     )

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -3,25 +3,25 @@ class Model < ApplicationRecord
   include PathBuilder
   include PathParser
 
+  scope :recent, -> { order(created_at: :desc) }
+
   belongs_to :library
   belongs_to :creator, optional: true
   belongs_to :collection, optional: true
-  has_many :model_files, dependent: :destroy
   belongs_to :preview_file, class_name: "ModelFile", optional: true
-  validates :name, presence: true
-  validates :path, presence: true, uniqueness: {scope: :library}
-  validate :cannot_move_models_with_submodels, on: :update
+  has_many :model_files, dependent: :destroy
   has_many :links, as: :linkable, dependent: :destroy
   has_many :problems, as: :problematic, dependent: :destroy
+  acts_as_taggable_on :tags
+
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
   attr_accessor :organize
 
-  before_update :move_files
+  validates :name, presence: true
+  validates :path, presence: true, uniqueness: {scope: :library}
 
-  scope :recent, -> { order(created_at: :desc) }
-
-  acts_as_taggable_on :tags
+  
 
   def parents
     Pathname.new(path).parent.descend.filter_map do |path|

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -22,6 +22,7 @@ class Model < ApplicationRecord
   validates :name, presence: true
   validates :path, presence: true, uniqueness: {scope: :library}
   validate :check_for_submodels, on: :update, if: :need_to_move_files?
+  validate :destination_is_vacant, on: :update, if: :need_to_move_files?
 
   
 
@@ -97,5 +98,10 @@ class Model < ApplicationRecord
     end
   end
 
+  def destination_is_vacant
+    if Dir.exist?(absolute_path)
+      errors.add(:path, "already exists")
+    end
+  end
   end
 end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -3,5 +3,9 @@ class Problem < ApplicationRecord
 
   validates :category, uniqueness: {scope: :problematic}, presence: true
 
-  enum :category, [:missing, :empty, :destination_exists]
+  enum :category, [
+    :missing,
+    :empty,
+    :destination_exists # No longer used, but kept for compatibility
+  ]
 end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -24,21 +24,21 @@ RSpec.describe Model do
   context "with a library on disk" do
     before do
       allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/library1").and_return(true)
-      allow(File).to receive(:exist?).with("/library2").and_return(true)
+      allow(File).to receive(:exist?).with("/original_library").and_return(true)
+      allow(File).to receive(:exist?).with("/new_library").and_return(true)
     end
 
     it "must have a unique path within its library" do
-      library = create(:library, path: "/library1")
+      library = create(:library, path: "/original_library")
       create(:model, library: library, path: "model")
       expect(build(:model, library: library, path: "model")).not_to be_valid
     end
 
     it "can have the same path as a model in a different library" do
-      library1 = create(:library, path: "/library1")
-      create(:model, library: library1, path: "model")
-      library2 = create(:library, path: "/library2")
-      expect(build(:model, library: library2, path: "model")).to be_valid
+      original_library = create(:library, path: "/original_library")
+      create(:model, library: original_library, path: "model")
+      new_library = create(:library, path: "/new_library")
+      expect(build(:model, library: new_library, path: "model")).to be_valid
     end
   end
 
@@ -95,6 +95,82 @@ RSpec.describe Model do
     it "correctly flags up contained models" do
       expect(parent.contains_other_models?).to be true
       expect(child.contains_other_models?).to be false
+    end
+  end
+
+  context "being organised" do
+    around do |ex|
+      Dir.mktmpdir do |library_path|
+        @library_path = library_path
+        ex.run
+      end
+    end
+
+    let(:library) { create(:library, path: @library_path) }
+    let!(:model) {
+      FileUtils.mkdir_p(File.join(library.path, "original"))
+      create(:model, library: library, name: "test model", path: "original")
+    }
+
+    it "moves model folder" do
+      expect { model.update! organize: true }.not_to raise_error
+      expect(Dir.exist?(File.join(library.path, "original"))).to be false
+      expect(Dir.exist?(File.join(library.path, "@untagged", "test-model#1"))).to be true
+    end
+
+    it "has a validation error if the destination path already exists, and does not move anything" do
+      FileUtils.mkdir_p(File.join(library.path, "@untagged/test-model#1"))
+      expect { model.update! organize: true }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(model.errors.full_messages).to include("Path already exists")
+      expect(Dir.exist?(File.join(library.path, "original"))).to be true
+    end
+
+    it "has a validation error if the model has submodels, and does not move anything" do
+      create(:model, library: library, name: "sub model", path: "original/submodel")
+      expect { model.update! organize: true }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(model.errors.full_messages).to include("Path can't be changed, model contains other models")
+      expect(Dir.exist?(File.join(library.path, "original"))).to be true
+      expect(Dir.exist?(File.join(library.path, "@untagged", "test-model#1"))).to be false
+    end
+  end
+
+  context "changing library" do
+    around do |ex|
+      Dir.mktmpdir do |library_path|
+        Dir.mkdir File.join(library_path, "original_library")
+        Dir.mkdir File.join(library_path, "new_library")
+        @library_path = library_path
+        ex.run
+      end
+    end
+
+    let(:original_library) { create(:library, path: File.join(@library_path, "original_library")) }
+    let(:new_library) { create(:library, path: File.join(@library_path, "new_library")) }
+    let!(:model) {
+      FileUtils.mkdir_p(File.join(original_library.path, "model"))
+      create(:model, library: original_library, name: "test model", path: "model")
+    }
+    let(:submodel) { create(:model, library: original_library, name: "sub model", path: "model/submodel") }
+
+    it "moves model folder" do
+      expect { model.update! library: new_library }.not_to raise_error
+      expect(Dir.exist?(File.join(original_library.path, "model"))).to be false
+      expect(Dir.exist?(File.join(new_library.path, "model"))).to be true
+    end
+
+    it "has a validation error if the destination path already exists, and does not move folder" do
+      FileUtils.mkdir_p(File.join(new_library.path, "model"))
+      expect { model.update! library: new_library }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(model.errors.full_messages).to include("Path already exists")
+      expect(Dir.exist?(File.join(original_library.path, "model"))).to be true
+    end
+
+    it "has a validation error if the model has submodels, and does not move anything" do
+      create(:model, library: original_library, name: "sub model", path: "model/submodel")
+      expect { model.update! library: new_library }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(model.errors.full_messages).to include("Library can't be changed, model contains other models")
+      expect(Dir.exist?(File.join(original_library.path, "model"))).to be true
+      expect(Dir.exist?(File.join(new_library.path, "model"))).to be false
     end
   end
 end


### PR DESCRIPTION
This PR refactors all the logic around changing model paths, whether when autoorganising, or changing library. destination_exists problems are not longer created, instead activerecord validation errors are thrown so the user can interactively resolve the problem. This also adds full test coverage for this functionality, and stops paths being changed if a model is just moved between libraries, not auto-organized.

Resolves #1060
Resolves #1039