### PR TITLE
Fix case handling in file scanner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem "rubocop-performance", "~> 1.15", require: false
   gem "i18n-tasks", "~> 1.0"
   gem "simplecov", "~> 0.22.0", require: false
+  gem "sys-filesystem", "~> 1.4"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,8 @@ GEM
       lint_roller (~> 1.0)
       rubocop-performance (~> 1.18.0)
     stopwords-filter2 (0.1.0)
+    sys-filesystem (1.4.3)
+      ffi (~> 1.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
@@ -504,6 +506,7 @@ DEPENDENCIES
   sqlite3_ar_regexp (~> 2.2)
   standard (~> 1.29.0)
   stopwords-filter2
+  sys-filesystem (~> 1.4)
   tzinfo-data
   web-console (>= 4.1.0)
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -10,9 +10,15 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def self.case_insensitive_glob(extensions)
-    lower = extensions.map(&:downcase)
-    upper = extensions.map(&:upcase)
-    "*.{#{lower.zip(upper).flatten.join(",")}}"
+    [
+      "*.{",
+      extensions.map { |ext|
+        ext.chars.map { |char|
+          "[#{char.upcase}#{char.downcase}]"
+        }.join
+      }.join(","),
+      "}"
+    ].join
   end
 
   def self.image_pattern

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe ApplicationJob do
   it "generates a case-insensitive pattern for all supported files" do
     pattern = described_class.file_pattern
-    expect(pattern).to include "stl,STL"
-    expect(pattern).to include "png,PNG"
+    expect(pattern).to include "[Ss][Tt][Ll],"
+    expect(pattern).to include "[Pp][Nn][Gg],"
   end
 
-  it "generates a case-insensitive pattern for iamge files" do
+  it "generates a case-insensitive pattern for image files" do
     pattern = described_class.image_pattern
-    expect(pattern).not_to include "stl,STL"
-    expect(pattern).to include "png,PNG"
+    expect(pattern).not_to include "[Ss][Tt][Ll],"
+    expect(pattern).to include "[Pp][Nn][Gg],"
   end
 end

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe LibraryScanJob do
     end
   end
 
-  context "with various case extensions" do
+  context "with a case sensitive filesystem", case_sensitive: true do
     around do |ex|
       MockDirectory.create([
         "model/file.obj",

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe LibraryScanJob do
   context "with various case extensions" do
     around do |ex|
       MockDirectory.create([
-        "model/file.stl",
-        "model/file.STL",
-        "model/file.Stl"
+        "model/file.obj",
+        "model/file.OBJ",
+        "model/file.Obj"
       ]) do |path|
         @library_path = path
         ex.run
@@ -51,7 +51,7 @@ RSpec.describe LibraryScanJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "detects lowercase file extensions" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.stl")
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.obj")
     end
 
     it "detects uppercase file extensions" do
@@ -59,7 +59,7 @@ RSpec.describe LibraryScanJob do
     end
 
     it "detects mixed case file extensions" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.Stl")
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.Obj")
     end
   end
 end

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe LibraryScanJob do
     end
 
     it "detects uppercase file extensions" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.STL")
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.OBJ")
     end
 
     it "detects mixed case file extensions" do

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -1,33 +1,65 @@
 require "rails_helper"
+require "support/mock_directory"
 
 RSpec.describe LibraryScanJob do
   before :all do
     ActiveJob::Base.queue_adapter = :test
   end
 
-  let(:library) do
-    create(:library, path: Rails.root.join("spec/fixtures/library"))
+  context "with fixtures" do
+    let(:library) do
+      create(:library, path: Rails.root.join("spec/fixtures/library"))
+    end
+
+    it "can scan a library directory" do
+      expect { described_class.perform_now(library) }.to change { library.models.count }.to(4)
+      expect(library.models.map(&:name)).to contain_exactly("Model One", "Model Two", "Nested Model", "Thingiverse Model")
+      expect(library.models.map(&:path)).to contain_exactly("/model_one", "/subfolder/model_two", "/model_one/nested_model", "/thingiverse_model")
+    end
+
+    it "queues up model scans" do
+      expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(4).times
+    end
+
+    it "only scans models with changes on rescan" do
+      model_one = create(:model, path: "model_one", library: library)
+      ModelScanJob.perform_now(model_one)
+      expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(3).times
+    end
+
+    it "flags models with no files as problems" do
+      lib = create(:library, path: File.join("/", "tmp"))
+      create(:model, library: lib, path: "missing")
+      expect { described_class.perform_now(lib) }.to change(Problem, :count).from(0).to(1)
+    end
   end
 
-  it "can scan a library directory" do
-    expect { described_class.perform_now(library) }.to change { library.models.count }.to(4)
-    expect(library.models.map(&:name)).to contain_exactly("Model One", "Model Two", "Nested Model", "Thingiverse Model")
-    expect(library.models.map(&:path)).to contain_exactly("/model_one", "/subfolder/model_two", "/model_one/nested_model", "/thingiverse_model")
-  end
+  context "with various case extensions" do
+    around do |ex|
+      MockDirectory.create([
+        "model/file.stl",
+        "model/file.STL",
+        "model/file.Stl"
+      ]) do |path|
+        @library_path = path
+        ex.run
+      end
+    end
 
-  it "queues up model scans" do
-    expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(4).times
-  end
+    # rubocop:disable RSpec/InstanceVariable
+    let(:library) { create(:library, path: @library_path) }
+    # rubocop:enable RSpec/InstanceVariable
 
-  it "only scans models with changes on rescan" do
-    model_one = create(:model, path: "model_one", library: library)
-    ModelScanJob.perform_now(model_one)
-    expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(3).times
-  end
+    it "detects lowercase file extensions" do
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.stl")
+    end
 
-  it "flags models with no files as problems" do
-    lib = create(:library, path: File.join("/", "tmp"))
-    create(:model, library: lib, path: "missing")
-    expect { described_class.perform_now(lib) }.to change(Problem, :count).from(0).to(1)
+    it "detects uppercase file extensions" do
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.STL")
+    end
+
+    it "detects mixed case file extensions" do
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.Stl")
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,13 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Exclude case-sensitive filesystem tests if our local filesystem isn't
+  Dir.mktmpdir do |tmp|
+    if Sys::Filesystem.stat(tmp).case_insensitive?
+      config.filter_run_excluding case_sensitive: true
+    end
+  end
+
   config.include Devise::Test::IntegrationHelpers, type: :request
 
   # Create the default admin user before tests

--- a/spec/support/mock_directory.rb
+++ b/spec/support/mock_directory.rb
@@ -1,0 +1,16 @@
+module MockDirectory
+  def self.create(file_list)
+    Dir.mktmpdir do |temp_path|
+      # Create file stubs
+      file_list.each do |f|
+        begin
+          FileUtils.mkdir_p(File.join(temp_path, File.dirname(f)))
+        rescue Errno::EEXIST
+          nil
+        end
+        FileUtils.touch(File.join(temp_path, f))
+      end
+      yield temp_path
+    end
+  end
+end


### PR DESCRIPTION
Add tests for different case in file extension, including mixed case. Resolves #1167 (I hope)