### PR TITLE
Remove separators from start/end of model paths, to avoid duplicates during scan

### DIFF
--- a/app/jobs/library_scan_job.rb
+++ b/app/jobs/library_scan_job.rb
@@ -73,7 +73,7 @@ class LibraryScanJob < ApplicationJob
       new_model_properties = {
         name: File.basename(path).humanize.tr("+", " ").titleize
       }
-      model = library.models.create_with(new_model_properties).find_or_create_by(path: path)
+      model = library.models.create_with(new_model_properties).find_or_create_by(path: path.gsub(/^#{File::SEPARATOR}/o, ""))
       if model.valid?
         ModelScanJob.perform_later(model)
       else

--- a/app/jobs/library_scan_job.rb
+++ b/app/jobs/library_scan_job.rb
@@ -73,7 +73,7 @@ class LibraryScanJob < ApplicationJob
       new_model_properties = {
         name: File.basename(path).humanize.tr("+", " ").titleize
       }
-      model = library.models.create_with(new_model_properties).find_or_create_by(path: path.gsub(/^#{File::SEPARATOR}/o, ""))
+      model = library.models.create_with(new_model_properties).find_or_create_by(path: path.trim_path_separators)
       if model.valid?
         ModelScanJob.perform_later(model)
       else

--- a/app/lib/trim_path_separators.rb
+++ b/app/lib/trim_path_separators.rb
@@ -1,0 +1,7 @@
+module TrimPathSeparators
+  TRIM_PATH_SEPARATOR_REGEXP = /(^#{File::SEPARATOR})|(#{File::SEPARATOR}$)/
+
+  def trim_path_separators
+    gsub(TRIM_PATH_SEPARATOR_REGEXP, "")
+  end
+end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -75,7 +75,7 @@ class Model < ApplicationRecord
   private
 
   def strip_separators_from_path
-    self.path = path&.gsub(/(^#{File::SEPARATOR})|(#{File::SEPARATOR}$)/o, "")
+    self.path = path&.trim_path_separators
   end
 
   def previous_library

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -16,6 +16,8 @@ class Model < ApplicationRecord
 
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
+  before_validation :strip_separators_from_path, if: :path_changed?
+
   attr_accessor :organize
   before_validation :autoupdate_path, if: :organize
 
@@ -71,6 +73,10 @@ class Model < ApplicationRecord
   end
 
   private
+
+  def strip_separators_from_path
+    self.path = path&.gsub(/(^#{File::SEPARATOR})|(#{File::SEPARATOR}$)/o, "")
+  end
 
   def previous_library
     library_id_changed? ? Library.find(library_id_was) : library

--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -1,0 +1,6 @@
+# Mixing in some extensions to core classes
+require "trim_path_separators"
+
+class String
+  include TrimPathSeparators
+end

--- a/db/data/20230613134254_remove_leading_separators_from_model_filenames.rb
+++ b/db/data/20230613134254_remove_leading_separators_from_model_filenames.rb
@@ -3,7 +3,7 @@
 class RemoveLeadingSeparatorsFromModelFilenames < ActiveRecord::Migration[7.0]
   def up
     Model.all.each do |model|
-      model.update! path: model.path&.gsub(/(^#{File::SEPARATOR})|(#{File::SEPARATOR}$)/o, "")
+      model.update! path: model.path&.trim_path_separators
     rescue ActiveRecord::RecordInvalid
       # If the path is invalid as it's already taken, this is a duplicate, so destroy it.
       model.destroy!

--- a/db/data/20230613134254_remove_leading_separators_from_model_filenames.rb
+++ b/db/data/20230613134254_remove_leading_separators_from_model_filenames.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RemoveLeadingSeparatorsFromModelFilenames < ActiveRecord::Migration[7.0]
+  def up
+    Model.all.each do |model|
+      model.update! path: model.path&.gsub(/(^#{File::SEPARATOR})|(#{File::SEPARATOR}$)/o, "")
+    rescue ActiveRecord::RecordInvalid
+      # If the path is invalid as it's already taken, this is a duplicate, so destroy it.
+      model.destroy!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230612080306)
+DataMigrate::Data.define(version: 20230613134254)

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LibraryScanJob do
     it "can scan a library directory" do
       expect { described_class.perform_now(library) }.to change { library.models.count }.to(4)
       expect(library.models.map(&:name)).to contain_exactly("Model One", "Model Two", "Nested Model", "Thingiverse Model")
-      expect(library.models.map(&:path)).to contain_exactly("/model_one", "/subfolder/model_two", "/model_one/nested_model", "/thingiverse_model")
+      expect(library.models.map(&:path)).to contain_exactly("model_one", "subfolder/model_two", "model_one/nested_model", "thingiverse_model")
     end
 
     it "queues up model scans" do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Model do
     expect(build(:model).model_files).to eq []
   end
 
+  it "strips leading and trailing separators from paths" do
+    model = create(:model, path: "/models/car/")
+    expect(model.path).to eq "models/car"
+  end
+
   context "with a library on disk" do
     before do
       allow(File).to receive(:exist?).and_call_original


### PR DESCRIPTION
Resolves #1093 