### PR TITLE
Fix error where server.pid stops docker container starting

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
 echo "Preparing database..."
 bundle exec rails db:prepare
 


### PR DESCRIPTION
Resolves #629

Remove tmp/pids/server.pid on docker start. See https://stackoverflow.com/a/38732187 for explanation.