### PR TITLE
Don't move files if the real path on disk hasn't actually changed

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -111,6 +111,10 @@ class Model < ApplicationRecord
   end
 
   def move_files
+    # Sometimes, if we're trimming separators or normalising paths, we get here
+    # but the path hasn't actually changed on disk. In that case, we're done.
+    return if absolute_path == previous_absolute_path
+    # Move the folder
     FileUtils.mkdir_p(File.dirname(absolute_path))
     File.rename(previous_absolute_path, absolute_path)
   end


### PR DESCRIPTION
This could happen when stripping separators during data migration, particularly, and if the path on disk is invalid, the migration explodes. This fixes that, and makes it all a bit safer by not touching disk unless we have to.