### PR TITLE
Improve matching of existing creators and collections from paths

### DIFF
--- a/app/jobs/library_scan_job.rb
+++ b/app/jobs/library_scan_job.rb
@@ -71,6 +71,7 @@ class LibraryScanJob < ApplicationJob
     # For each folder in the library with a change, find or create a model, then scan it
     folders_with_changes.each do |path|
       new_model_properties = {
+        # Initial best guess at name, this might be overwritten later by path parser
         name: File.basename(path).humanize.tr("+", " ").titleize
       }
       model = library.models.create_with(new_model_properties).find_or_create_by(path: path.trim_path_separators)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,6 +5,8 @@ class Collection < ApplicationRecord
   belongs_to :collection, optional: true
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
+  before_validation :slugify_name, if: :name_changed?
+
   default_scope { order(:name) }
   # returns all collections at and below given ids
   #   this should be applied to @filters[:collection] to get models in sub-trees
@@ -58,4 +60,10 @@ class Collection < ApplicationRecord
   #         JOIN collections ON collections.collection_id = search_tree.id
   #         WHERE NOT collections.id IN (path)
   #     )  SELECT * FROM search_tree
+
+  private
+
+  def slugify_name
+    self.slug = name.parameterize
+  end
 end

--- a/app/models/concerns/path_builder.rb
+++ b/app/models/concerns/path_builder.rb
@@ -9,11 +9,11 @@ module PathBuilder
           File.join(tags.order(taggings_count: :desc).map(&:to_s).map(&:parameterize)) :
           "@untagged"
       when "{creator}"
-        safe(creator&.name) || "@unattributed"
+        path_component(creator) || "@unattributed"
       when "{collection}"
-        safe(collection&.name) || "@uncollected"
+        path_component(collection) || "@uncollected"
       when "{modelName}"
-        safe(name)
+        path_component(self)
       when "{modelId}"
         "##{id}"
       else
@@ -24,7 +24,8 @@ module PathBuilder
 
   private
 
-  def safe(str)
-    SiteSettings.safe_folder_names ? str&.parameterize : str
+  def path_component(object)
+    return nil if object.nil?
+    SiteSettings.safe_folder_names ? object.slug : object.name
   end
 end

--- a/app/models/concerns/path_parser.rb
+++ b/app/models/concerns/path_parser.rb
@@ -26,6 +26,9 @@ module PathParser
           name: components[:collection].humanize.titleize
         )
     end
+    if components[:model_name]
+      self.name = components[:model_name].humanize.titleize
+    end
     save!
   end
 end

--- a/app/models/concerns/path_parser.rb
+++ b/app/models/concerns/path_parser.rb
@@ -12,8 +12,20 @@ module PathParser
     if components[:tags].present?
       tag_list.add(remove_stop_words(components[:tags]))
     end
-    self.creator = Creator.find_or_create_by(name: components[:creator]) if components[:creator]
-    self.collection = Collection.find_or_create_by(name: components[:collection]) if components[:collection]
+    if components[:creator]
+      self.creator =
+        Creator.find_by(slug: components[:creator]) ||
+        Creator.create_with(slug: components[:creator].parameterize).find_or_create_by(
+          name: components[:creator].humanize.titleize
+        )
+    end
+    if components[:collection]
+      self.collection =
+        Collection.find_by(slug: components[:collection]) ||
+        Collection.create_with(slug: components[:collection].parameterize).find_or_create_by(
+          name: components[:collection].humanize.titleize
+        )
+    end
     save!
   end
 end

--- a/app/models/concerns/path_parser.rb
+++ b/app/models/concerns/path_parser.rb
@@ -12,22 +12,10 @@ module PathParser
     if components[:tags].present?
       tag_list.add(remove_stop_words(components[:tags]))
     end
-    if components[:creator]
-      self.creator =
-        Creator.find_by(slug: components[:creator]) ||
-        Creator.create_with(slug: components[:creator].parameterize).find_or_create_by(
-          name: components[:creator].humanize.titleize
-        )
-    end
-    if components[:collection]
-      self.collection =
-        Collection.find_by(slug: components[:collection]) ||
-        Collection.create_with(slug: components[:collection].parameterize).find_or_create_by(
-          name: components[:collection].humanize.titleize
-        )
-    end
+    self.creator = find_or_create_from_path_component(Creator, components[:creator]) if components[:creator]
+    self.collection = find_or_create_from_path_component(Collection, components[:collection]) if components[:collection]
     if components[:model_name]
-      self.name = components[:model_name].humanize.titleize
+      self.name = to_human_name(components[:model_name])
     end
     save!
   end
@@ -69,4 +57,15 @@ def remove_stop_words(words)
     SiteSettings.model_tags_custom_stop_words
   )
   stopword_filter.filter(words)
+end
+
+def find_or_create_from_path_component(klass, path_component)
+  klass.find_by(slug: path_component) ||
+    klass.create_with(slug: path_component.parameterize).find_or_create_by(
+      name: to_human_name(path_component)
+    )
+end
+
+def to_human_name(str)
+  str.humanize.tr("+", " ").titleize
 end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -4,4 +4,12 @@ class Creator < ApplicationRecord
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
   default_scope { order(:name) }
+
+  before_validation :slugify_name, if: :name_changed?
+
+  private
+
+  def slugify_name
+    self.slug = name.parameterize
+  end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -17,6 +17,7 @@ class Model < ApplicationRecord
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
 
   before_validation :strip_separators_from_path, if: :path_changed?
+  before_validation :slugify_name, if: :name_changed?
 
   attr_accessor :organize
   before_validation :autoupdate_path, if: :organize
@@ -117,5 +118,9 @@ class Model < ApplicationRecord
     # Move the folder
     FileUtils.mkdir_p(File.dirname(absolute_path))
     File.rename(previous_absolute_path, absolute_path)
+  end
+
+  def slugify_name
+    self.slug = name.parameterize
   end
 end

--- a/db/data/20230617222353_generate_slugs.rb
+++ b/db/data/20230617222353_generate_slugs.rb
@@ -2,15 +2,15 @@
 
 class GenerateSlugs < ActiveRecord::Migration[7.0]
   def up
-    Model.where(slug: nil) do |model|
+    Model.where(slug: nil).each do |model|
       model.send(:slugify_name)
       model.save!(validate: false)
     end
-    Creator.where(slug: nil) do |creator|
+    Creator.where(slug: nil).each do |creator|
       creator.send(:slugify_name)
       creator.save!(validate: false)
     end
-    Collection.where(slug: nil) do |collection|
+    Collection.where(slug: nil).each do |collection|
       collection.send(:slugify_name)
       collection.save!(validate: false)
     end

--- a/db/data/20230617222353_generate_slugs.rb
+++ b/db/data/20230617222353_generate_slugs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class GenerateSlugs < ActiveRecord::Migration[7.0]
+  def up
+    Model.where(slug: nil) do |model|
+      model.send(:slugify_name)
+      model.save!(validate: false)
+    end
+    Creator.where(slug: nil) do |creator|
+      creator.send(:slugify_name)
+      creator.save!(validate: false)
+    end
+    Collection.where(slug: nil) do |collection|
+      collection.send(:slugify_name)
+      collection.save!(validate: false)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230613134254)
+DataMigrate::Data.define(version: 20230617222353)

--- a/db/migrate/20230615135601_add_slugs.rb
+++ b/db/migrate/20230615135601_add_slugs.rb
@@ -1,0 +1,10 @@
+class AddSlugs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :models, :slug, :string
+    add_index :models, :slug
+    add_column :collections, :slug, :string
+    add_index :collections, :slug
+    add_column :creators, :slug, :string
+    add_index :creators, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_24_000000) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_15_135601) do
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.text "notes"
@@ -18,7 +18,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "collection_id"
+    t.string "slug"
     t.index ["collection_id"], name: "index_collections_on_collection_id"
+    t.index ["slug"], name: "index_collections_on_slug"
   end
 
   create_table "creators", force: :cascade do |t|
@@ -27,6 +29,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_000000) do
     t.datetime "updated_at", null: false
     t.text "notes"
     t.text "caption"
+    t.string "slug"
+    t.index ["slug"], name: "index_creators_on_slug"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
@@ -93,10 +97,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_000000) do
     t.text "notes"
     t.text "caption"
     t.integer "collection_id"
+    t.string "slug"
     t.index ["collection_id"], name: "index_models_on_collection_id"
     t.index ["creator_id"], name: "index_models_on_creator_id"
     t.index ["library_id"], name: "index_models_on_library_id"
     t.index ["preview_file_id"], name: "index_models_on_preview_file_id"
+    t.index ["slug"], name: "index_models_on_slug"
   end
 
   create_table "problems", force: :cascade do |t|

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,6 +3,6 @@ require "rails_helper"
 RSpec.describe Collection do
   it "automatically generates a slug from the name" do
     collection = create(:collection, name: "Spın̈al Tap")
-    expect(collection.slug).to eq "spinal-tap"
+    expect(collection.slug).to eq "spin-al-tap"
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Collection do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "automatically generates a slug from the name" do
+    collection = create(:collection, name: "Spın̈al Tap")
+    expect(collection.slug).to eq "spinal-tap"
+  end
 end

--- a/spec/models/concerns/path_parser_spec.rb
+++ b/spec/models/concerns/path_parser_spec.rb
@@ -146,27 +146,27 @@ RSpec.describe PathParser do
     it "parses creator" do
       allow(SiteSettings).to receive(:model_path_template).and_return("{creator}/{modelName}{modelId}")
       model.parse_metadata_from_path!
-      expect(model.creator.name).to eq "greedy"
+      expect(model.creator.name).to eq "Greedy"
     end
 
     it "parses collection" do
       allow(SiteSettings).to receive(:model_path_template).and_return("{collection}/{modelName}{modelId}")
       model.parse_metadata_from_path!
-      expect(model.collection.name).to eq "greedy"
+      expect(model.collection.name).to eq "Greedy"
     end
 
     it "parses everything at once" do
       allow(SiteSettings).to receive(:model_path_template).and_return("{creator}/{collection}/{tags}/{modelName}{modelId}")
       model.parse_metadata_from_path!
-      expect(model.creator.name).to eq "library1"
-      expect(model.collection.name).to eq "stuff"
+      expect(model.creator.name).to eq "Library1"
+      expect(model.collection.name).to eq "Stuff"
       expect(model.tag_list).to eq ["tags", "are", "greedy"]
     end
 
     it "ignores extra path components" do
       allow(SiteSettings).to receive(:model_path_template).and_return("{creator}/{modelName}{modelId}")
       model.parse_metadata_from_path!
-      expect(model.creator.name).to eq "greedy"
+      expect(model.creator.name).to eq "Greedy"
       expect(model.collection).to be_nil
       expect(model.tag_list).to eq []
     end
@@ -194,8 +194,15 @@ RSpec.describe PathParser do
       allow(SiteSettings).to receive(:model_path_template).and_return("{creator}/{modelName}")
     end
 
-    it "creates a new creator with a humanized name if there's no match" do
-      model = build(:model, path: "/bruce-wayne/model-name")
+    it "creates a new creator from a human name if there's no match" do
+      model = build(:model, path: "Bruce Wayne/model-name")
+      model.parse_metadata_from_path!
+      expect(model.creator.name).to eq "Bruce Wayne"
+      expect(model.creator.slug).to eq "bruce-wayne"
+    end
+
+    it "creates a new creator from a slug if there's no match" do
+      model = build(:model, path: "bruce-wayne/model-name")
       model.parse_metadata_from_path!
       expect(model.creator.name).to eq "Bruce Wayne"
       expect(model.creator.slug).to eq "bruce-wayne"
@@ -205,13 +212,13 @@ RSpec.describe PathParser do
       let!(:creator) { create(:creator, name: "Bruce Wayne", slug: "bruce-wayne") }
 
       it "matches safe path components" do
-        model = build(:model, path: "/bruce-wayne/model-name")
+        model = build(:model, path: "bruce-wayne/model-name")
         model.parse_metadata_from_path!
         expect(model.creator).to eq creator
       end
 
       it "matches unsafe path components" do
-        model = build(:model, path: "/Bruce Wayne/model-name")
+        model = build(:model, path: "Bruce Wayne/model-name")
         model.parse_metadata_from_path!
         expect(model.creator).to eq creator
       end
@@ -223,8 +230,15 @@ RSpec.describe PathParser do
       allow(SiteSettings).to receive(:model_path_template).and_return("{collection}/{modelName}")
     end
 
-    it "creates a new collection with a humanized name if there's no match" do
-      model = build(:model, path: "/wonderful-toys/model-name")
+    it "creates a new collection from a human name if there's no match" do
+      model = build(:model, path: "Wonderful Toys/model-name")
+      model.parse_metadata_from_path!
+      expect(model.collection.name).to eq "Wonderful Toys"
+      expect(model.collection.slug).to eq "wonderful-toys"
+    end
+
+    it "creates a new collection from a slug if there's no match" do
+      model = build(:model, path: "wonderful-toys/model-name")
       model.parse_metadata_from_path!
       expect(model.collection.name).to eq "Wonderful Toys"
       expect(model.collection.slug).to eq "wonderful-toys"
@@ -234,13 +248,13 @@ RSpec.describe PathParser do
       let!(:collection) { create(:collection, name: "Wonderful Toys", slug: "wonderful-toys") }
 
       it "matches safe path components" do
-        model = build(:model, path: "/wonderful-toys/model-name")
+        model = build(:model, path: "wonderful-toys/model-name")
         model.parse_metadata_from_path!
         expect(model.collection).to eq collection
       end
 
       it "matches unsafe path components" do
-        model = build(:model, path: "/Wonderful Toys/model-name")
+        model = build(:model, path: "Wonderful Toys/model-name")
         model.parse_metadata_from_path!
         expect(model.collection).to eq collection
       end

--- a/spec/models/concerns/path_parser_spec.rb
+++ b/spec/models/concerns/path_parser_spec.rb
@@ -268,4 +268,13 @@ RSpec.describe PathParser do
     expect(model.name).to eq "Model Name"
     expect(model.slug).to eq "model-name"
   end
+
+  it "handles paths matching a complex templates" do
+    allow(SiteSettings).to receive(:model_path_template).and_return("{tags}/{creator} - {modelName}{modelId}")
+    model = build(:model, path: "human/wizard/bruce-wayne - model-name#1234")
+    model.parse_metadata_from_path!
+    expect(model.name).to eq "Model Name"
+    expect(model.creator.name).to eq "Bruce Wayne"
+    expect(model.tag_list).to eq ["human", "wizard"]
+  end
 end

--- a/spec/models/concerns/path_parser_spec.rb
+++ b/spec/models/concerns/path_parser_spec.rb
@@ -260,4 +260,12 @@ RSpec.describe PathParser do
       end
     end
   end
+
+  it "discards model ID and doesn't include it in model name" do
+    allow(SiteSettings).to receive(:model_path_template).and_return("{modelName}{modelId}")
+    model = build(:model, path: "model-name#1234")
+    model.parse_metadata_from_path!
+    expect(model.name).to eq "Model Name"
+    expect(model.slug).to eq "model-name"
+  end
 end

--- a/spec/models/concerns/path_parser_spec.rb
+++ b/spec/models/concerns/path_parser_spec.rb
@@ -188,4 +188,62 @@ RSpec.describe PathParser do
       expect(model.tag_list).to eq ["library1", "tags", "greedy"]
     end
   end
+
+  context "when parsing creator out of a path" do
+    before do
+      allow(SiteSettings).to receive(:model_path_template).and_return("{creator}/{modelName}")
+    end
+
+    it "creates a new creator with a humanized name if there's no match" do
+      model = build(:model, path: "/bruce-wayne/model-name")
+      model.parse_metadata_from_path!
+      expect(model.creator.name).to eq "Bruce Wayne"
+      expect(model.creator.slug).to eq "bruce-wayne"
+    end
+
+    context "with an existing creator" do
+      let!(:creator) { create(:creator, name: "Bruce Wayne", slug: "bruce-wayne") }
+
+      it "matches safe path components" do
+        model = build(:model, path: "/bruce-wayne/model-name")
+        model.parse_metadata_from_path!
+        expect(model.creator).to eq creator
+      end
+
+      it "matches unsafe path components" do
+        model = build(:model, path: "/Bruce Wayne/model-name")
+        model.parse_metadata_from_path!
+        expect(model.creator).to eq creator
+      end
+    end
+  end
+
+  context "when parsing collection out of a path" do
+    before do
+      allow(SiteSettings).to receive(:model_path_template).and_return("{collection}/{modelName}")
+    end
+
+    it "creates a new collection with a humanized name if there's no match" do
+      model = build(:model, path: "/wonderful-toys/model-name")
+      model.parse_metadata_from_path!
+      expect(model.collection.name).to eq "Wonderful Toys"
+      expect(model.collection.slug).to eq "wonderful-toys"
+    end
+
+    context "with an existing collection" do
+      let!(:collection) { create(:collection, name: "Wonderful Toys", slug: "wonderful-toys") }
+
+      it "matches safe path components" do
+        model = build(:model, path: "/wonderful-toys/model-name")
+        model.parse_metadata_from_path!
+        expect(model.collection).to eq collection
+      end
+
+      it "matches unsafe path components" do
+        model = build(:model, path: "/Wonderful Toys/model-name")
+        model.parse_metadata_from_path!
+        expect(model.collection).to eq collection
+      end
+    end
+  end
 end

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -3,6 +3,6 @@ require "rails_helper"
 RSpec.describe Creator do
   it "automatically generates a slug from the name" do
     creator = create(:creator, name: "Spın̈al Tap")
-    expect(creator.slug).to eq "spinal-tap"
+    expect(creator.slug).to eq "spin-al-tap"
   end
 end

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -1,5 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Creator do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "automatically generates a slug from the name" do
+    creator = create(:creator, name: "Spın̈al Tap")
+    expect(creator.slug).to eq "spinal-tap"
+  end
 end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Model do
 
   it "automatically generates a slug from the name" do
     model = create(:model, name: "Spın̈al Tap")
-    expect(model.slug).to eq "spinal-tap"
+    expect(model.slug).to eq "spin-al-tap"
   end
 
   context "with a library on disk" do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Model do
     expect(model.path).to eq "models/car"
   end
 
+  it "automatically generates a slug from the name" do
+    model = create(:model, name: "Spın̈al Tap")
+    expect(model.slug).to eq "spinal-tap"
+  end
+
   context "with a library on disk" do
     before do
       allow(File).to receive(:exist?).and_call_original


### PR DESCRIPTION
By adding a stable "slug" to Model, Creator, and Collection, we make it possible to query the "safe" file paths for these things when we want to parse the metadata out of the file paths, thus making matching existing records a lot easier. The slug is not user-editable, but is autocreated from the name whenever it changes.

Resolves #1086 

Also fixes inclusion of Model ID components in names when scanning.