### PR TITLE
ignore directories that look like files in ModelScanJob

### DIFF
--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -31,7 +31,7 @@ class ModelScanJob < ApplicationJob
         File.join(dir.path, ApplicationJob.file_pattern),
         File.join(dir.path, "files", ApplicationJob.file_pattern),
         File.join(dir.path, "images", ApplicationJob.image_pattern)
-      ]).uniq.each do |filename|
+      ]).uniq.filter { |x| File.file?(x) }.each do |filename|
         # Create the file
         file = model.model_files.find_or_create_by(filename: filename.gsub(model_path + "/", ""))
         ModelFileScanJob.perform_later(file) if file.valid?


### PR DESCRIPTION
File lists are built in ModelScanJob as well as LibraryScanJob (one for the refactor in #1280), so this fix is also needed to resolve #628 properly