### PR TITLE
Analyse and show file size for model files

### DIFF
--- a/app/jobs/library_scan_job.rb
+++ b/app/jobs/library_scan_job.rb
@@ -45,5 +45,9 @@ class LibraryScanJob < ApplicationJob
     library.models.each do |model|
       Scan::CheckModelIntegrityJob.perform_later(model)
     end
+    # Run analysis job on ModelFiles that might be missing data
+    library.model_files.where(digest: nil).or(library.model_files.where(size: nil)).each do |file|
+      Scan::AnalyseModelFileJob.perform_later(file)
+    end
   end
 end

--- a/app/jobs/model_file_scan_job.rb
+++ b/app/jobs/model_file_scan_job.rb
@@ -9,7 +9,10 @@ class ModelFileScanJob < ApplicationJob
     ).empty?
       file.update!(presupported: true)
     end
-    # Calculate digest
-    file.update!(digest: file.calculate_digest)
+    # Store file stats
+    file.update!(
+      digest: file.calculate_digest,
+      size: File.size(file.pathname)
+    )
   end
 end

--- a/app/jobs/model_file_scan_job.rb
+++ b/app/jobs/model_file_scan_job.rb
@@ -9,10 +9,7 @@ class ModelFileScanJob < ApplicationJob
     ).empty?
       file.update!(presupported: true)
     end
-    # Store file stats
-    file.update!(
-      digest: file.calculate_digest,
-      size: File.size(file.pathname)
-    )
+    # Queue up deeper analysis job
+    Scan::AnalyseModelFileJob.perform_later(file)
   end
 end

--- a/app/jobs/scan/analyse_model_file_job.rb
+++ b/app/jobs/scan/analyse_model_file_job.rb
@@ -1,0 +1,11 @@
+class Scan::AnalyseModelFileJob < ApplicationJob
+  queue_as :scan
+
+  def perform(file)
+    # Update stored file metadata if not set
+    file.update!(
+      digest: file.digest || file.calculate_digest,
+      size: file.size || File.size(file.pathname)
+    )
+  end
+end

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -21,6 +21,11 @@
           Digest: <code><%= @file.digest.slice(0,16) %></code>
         </p>
       <% end %>
+      <% if @file.size %>
+        <p>
+          File size: <code><%= number_to_human_size @file.size, precision: 2 %></code>
+        </p>
+      <% end %>
       <%= render 'form' %>
     <% end %>
 

--- a/db/migrate/20230707082403_add_size_to_model_files.rb
+++ b/db/migrate/20230707082403_add_size_to_model_files.rb
@@ -1,0 +1,5 @@
+class AddSizeToModelFiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :model_files, :size, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_28_195018) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_07_082403) do
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.text "notes"
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_195018) do
     t.string "digest"
     t.text "notes"
     t.text "caption"
+    t.integer "size"
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["model_id"], name: "index_model_files_on_model_id"
   end

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe LibraryScanJob do
       ModelScanJob.perform_now(model_one)
       expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(1).times
     end
+
   end
 
   context "with nested models" do

--- a/spec/jobs/library_scan_job_spec.rb
+++ b/spec/jobs/library_scan_job_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe LibraryScanJob do
       ModelScanJob.perform_now(model_one)
       expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(1).times
     end
-
   end
 
   context "with nested models" do

--- a/spec/jobs/model_file_scan_job_spec.rb
+++ b/spec/jobs/model_file_scan_job_spec.rb
@@ -5,17 +5,22 @@ RSpec.describe ModelFileScanJob do
     ActiveJob::Base.queue_adapter = :test
   end
 
+  let(:file) { create :model_file }
+  let(:supported_file) { create :model_file, filename: "file1_supported.stl" }
+
   it "detects if file is presupported" do
-    model_file = create(:model_file, filename: "file1_supported.stl")
-    described_class.perform_now(model_file)
-    model_file.reload
-    expect(model_file.presupported).to be true
+    described_class.perform_now(supported_file)
+    supported_file.reload
+    expect(supported_file.presupported).to be true
   end
 
   it "detects if file is unsupported" do
-    model_file = create(:model_file)
-    described_class.perform_now(model_file)
-    model_file.reload
-    expect(model_file.presupported).to be false
+    described_class.perform_now(file)
+    file.reload
+    expect(file.presupported).to be false
+  end
+
+  it "queues analysis job" do
+    expect { described_class.perform_now(file) }.to have_enqueued_job(Scan::AnalyseModelFileJob).once
   end
 end

--- a/spec/jobs/model_file_scan_job_spec.rb
+++ b/spec/jobs/model_file_scan_job_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe ModelFileScanJob do
     ActiveJob::Base.queue_adapter = :test
   end
 
-  let(:file) { create :model_file }
-  let(:supported_file) { create :model_file, filename: "file1_supported.stl" }
+  let(:file) { create(:model_file) }
+  let(:supported_file) { create(:model_file, filename: "file1_supported.stl") }
 
   it "detects if file is presupported" do
     described_class.perform_now(supported_file)

--- a/spec/jobs/scan/analyse_model_file_job_spec.rb
+++ b/spec/jobs/scan/analyse_model_file_job_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 require "support/mock_directory"
 
 RSpec.describe Scan::AnalyseModelFileJob do
-
   it "calculates file digest if not set" do
     file = create(:model_file, digest: nil, size: 10)
     allow(file).to receive(:calculate_digest).once.and_return("deadbeef")

--- a/spec/jobs/scan/analyse_model_file_job_spec.rb
+++ b/spec/jobs/scan/analyse_model_file_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "support/mock_directory"
+
+RSpec.describe Scan::AnalyseModelFileJob do
+
+  it "calculates file digest if not set" do
+    file = create(:model_file, digest: nil, size: 10)
+    allow(file).to receive(:calculate_digest).once.and_return("deadbeef")
+    described_class.perform_now file
+    expect(file.digest).to eq "deadbeef"
+  end
+
+  it "calculates file size if not set" do
+    file = create(:model_file, digest: "deadbeef", size: nil)
+    allow(File).to receive(:size).once.and_return(1234)
+    described_class.perform_now file
+    expect(file.size).to eq 1234
+  end
+end


### PR DESCRIPTION
Contributes to #909 - we'll use file size as a control on whether or not previews are rendered automatically

<img width="407" alt="Screenshot 2023-07-07 at 12 42 56" src="https://github.com/Floppy/van_dam/assets/3565/75ae61f1-2dda-49fd-a825-df4d9b5b1be7">
