### PR TITLE
Clear old jobs on docker startup

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -7,5 +7,8 @@ fi
 echo "Preparing database..."
 bundle exec rails db:prepare:with_data
 
+echo "Clearing up old jobs..."
+bundle exec rake jobs:clear
+
 echo "Launching application..."
 exec "$@"


### PR DESCRIPTION
To avoid old jobs conflicting with new code, if they persist over a deployment