### PR TITLE
Speed up "scan for changes" jobs by removing duplication with "check existing models"

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -25,7 +25,7 @@ class LibrariesController < ApplicationController
     @library = Library.create(library_params)
     @library.tag_regex = params[:tag_regex]
     if @library.valid?
-      LibraryScanJob.perform_later(@library)
+      Scan::DetectFilesystemChangesJob.perform_later(@library)
       redirect_to @library
     else
       render :new
@@ -41,7 +41,7 @@ class LibrariesController < ApplicationController
   end
 
   def scan
-    LibraryScanJob.perform_later(@library)
+    Scan::DetectFilesystemChangesJob.perform_later(@library)
     redirect_to @library
   end
 
@@ -50,7 +50,7 @@ class LibrariesController < ApplicationController
       Scan::CheckAllJob.perform_later
     else
       Library.all.each do |library|
-        LibraryScanJob.perform_later(library)
+        Scan::DetectFilesystemChangesJob.perform_later(library)
       end
     end
     redirect_to models_path

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,7 +4,7 @@ class UploadsController < ApplicationController
     save_files(params[:upload], File.join(library.path, ""))
 
     if params[:post][:scan_after_upload] == "1"
-      LibraryScanJob.perform_later(library)
+      Scan::DetectFilesystemChangesJob.perform_later(library)
     end
     redirect_to libraries_path
   end

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -1,4 +1,4 @@
-class LibraryScanJob < ApplicationJob
+class Scan::DetectFilesystemChangesJob < ApplicationJob
   queue_as :default
 
   # Find all files in the library that we might need to look at
@@ -40,14 +40,6 @@ class LibraryScanJob < ApplicationJob
         Rails.logger.error(model.inspect)
         Rails.logger.error(model.errors.full_messages.inspect)
       end
-    end
-    # Run integrity check on all models
-    library.models.each do |model|
-      Scan::CheckModelIntegrityJob.perform_later(model)
-    end
-    # Run analysis job on ModelFiles that might be missing data
-    library.model_files.where(digest: nil).or(library.model_files.where(size: nil)).each do |file|
-      Scan::AnalyseModelFileJob.perform_later(file)
     end
   end
 end

--- a/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
+++ b/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "support/mock_directory"
 
-RSpec.describe LibraryScanJob do
+RSpec.describe Scan::DetectFilesystemChangesJob do
   before do
     ActiveJob::Base.queue_adapter = :test
   end


### PR DESCRIPTION
Rename LibraryScanJob to DetectFilesystemChangesJob and remove integrity checks now that they can be run separately.