### PR TITLE
Allow scan jobs to soft-fail

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -25,7 +25,7 @@ class LibrariesController < ApplicationController
     @library = Library.create(library_params)
     @library.tag_regex = params[:tag_regex]
     if @library.valid?
-      Scan::DetectFilesystemChangesJob.perform_later(@library)
+      Scan::DetectFilesystemChangesJob.perform_later(@library.id)
       redirect_to @library
     else
       render :new
@@ -41,7 +41,7 @@ class LibrariesController < ApplicationController
   end
 
   def scan
-    Scan::DetectFilesystemChangesJob.perform_later(@library)
+    Scan::DetectFilesystemChangesJob.perform_later(@library.id)
     redirect_to @library
   end
 
@@ -50,7 +50,7 @@ class LibrariesController < ApplicationController
       Scan::CheckAllJob.perform_later
     else
       Library.all.each do |library|
-        Scan::DetectFilesystemChangesJob.perform_later(library)
+        Scan::DetectFilesystemChangesJob.perform_later(library.id)
       end
     end
     redirect_to models_path

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -47,13 +47,13 @@ class ModelsController < ApplicationController
   def merge
     if params[:target] && (target = (@model.parents.find { |x| x.id == params[:target].to_i }))
       @model.merge_into! target
-      Scan::CheckModelIntegrityJob.perform_later(target)
+      Scan::CheckModelIntegrityJob.perform_later(target.id)
       redirect_to [@library, target]
     elsif params[:all] && @model.contains_other_models?
       @model.contained_models.each do |child|
         child.merge_into! @model
       end
-      Scan::CheckModelIntegrityJob.perform_later(@model)
+      Scan::CheckModelIntegrityJob.perform_later(@model.id)
       redirect_to [@library, @model]
     else
       render status: :bad_request

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,7 +4,7 @@ class UploadsController < ApplicationController
     save_files(params[:upload], File.join(library.path, ""))
 
     if params[:post][:scan_after_upload] == "1"
-      Scan::DetectFilesystemChangesJob.perform_later(library)
+      Scan::DetectFilesystemChangesJob.perform_later(library.id)
     end
     redirect_to libraries_path
   end

--- a/app/jobs/model_file_scan_job.rb
+++ b/app/jobs/model_file_scan_job.rb
@@ -1,7 +1,9 @@
 class ModelFileScanJob < ApplicationJob
   queue_as :default
 
-  def perform(file)
+  def perform(file_id)
+    file = ModelFile.find(file_id)
+    return if file.nil?
     # Try to guess if the file is presupported
     if !(
       file.pathname.split(/[[:punct:]]|[[:space:]]/).map(&:downcase) &
@@ -10,6 +12,6 @@ class ModelFileScanJob < ApplicationJob
       file.update!(presupported: true)
     end
     # Queue up deeper analysis job
-    Scan::AnalyseModelFileJob.perform_later(file)
+    Scan::AnalyseModelFileJob.perform_later(file.id)
   end
 end

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -18,14 +18,17 @@ class ModelScanJob < ApplicationJob
     list
   end
 
-  def perform(model)
+  def perform(model_id)
+    model = Model.find(model_id)
+    return if model.nil?
+
     model_path = File.join(model.library.path, model.path)
     return if Problem.create_or_clear(model, :missing, !File.exist?(model_path))
     # For each file in the model, create a file object
     file_list(model_path).each do |filename|
       # Create the file
       file = model.model_files.find_or_create_by(filename: filename.gsub(model_path + "/", ""))
-      ModelFileScanJob.perform_later(file) if file.valid?
+      ModelFileScanJob.perform_later(file.id) if file.valid?
     end
     # Set tags and default files
     model.model_files.reload

--- a/app/jobs/scan/analyse_model_file_job.rb
+++ b/app/jobs/scan/analyse_model_file_job.rb
@@ -1,7 +1,9 @@
 class Scan::AnalyseModelFileJob < ApplicationJob
   queue_as :scan
 
-  def perform(file)
+  def perform(file_id)
+    file = ModelFile.find(file_id)
+    return if file.nil?
     # Don't run analysis if the file is missing
     # The Problem is raised elsewhere.
     return if !File.exist?(file.pathname)

--- a/app/jobs/scan/check_all_job.rb
+++ b/app/jobs/scan/check_all_job.rb
@@ -4,10 +4,10 @@ class Scan::CheckAllJob < ApplicationJob
   def perform
     # Run integrity check on all models
     Model.all.each do |model|
-      Scan::CheckModelIntegrityJob.perform_later(model)
+      Scan::CheckModelIntegrityJob.perform_later(model.id)
       # Run analysis job on individual files
       model.model_files.each do |file|
-        Scan::AnalyseModelFileJob.perform_later(file)
+        Scan::AnalyseModelFileJob.perform_later(file.id)
       end
     end
   end

--- a/app/jobs/scan/check_model_integrity_job.rb
+++ b/app/jobs/scan/check_model_integrity_job.rb
@@ -1,7 +1,9 @@
 class Scan::CheckModelIntegrityJob < ApplicationJob
   queue_as :scan
 
-  def perform(model)
+  def perform(model_id)
+    model = Model.find(model_id)
+    return if model.nil?
     Problem.create_or_clear(model, :missing, !File.exist?(File.join(model.library.path, model.path)))
     Problem.create_or_clear model, :empty, (model.model_files.count == 0)
     Problem.create_or_clear model, :nesting, model.contains_other_models?

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -56,7 +56,7 @@ class ModelFile < ApplicationRecord
     # Delete actual file
     FileUtils.rm(pathname) if File.exist?(pathname)
     # Rescan any duplicates
-    duplicates.each { |x| Scan::AnalyseModelFileJob.perform_later(x) }
+    duplicates.each { |x| Scan::AnalyseModelFileJob.perform_later(x.id) }
     # Remove the db record
     destroy
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,7 +101,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_111009) do
     t.string "digest"
     t.text "notes"
     t.text "caption"
-    t.bigint "size"
+    t.integer "size"
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["model_id"], name: "index_model_files_on_model_id"
   end

--- a/spec/jobs/model_file_scan_job_spec.rb
+++ b/spec/jobs/model_file_scan_job_spec.rb
@@ -9,18 +9,18 @@ RSpec.describe ModelFileScanJob do
   let(:supported_file) { create(:model_file, filename: "file1_supported.stl") }
 
   it "detects if file is presupported" do
-    described_class.perform_now(supported_file)
+    described_class.perform_now(supported_file.id)
     supported_file.reload
     expect(supported_file.presupported).to be true
   end
 
   it "detects if file is unsupported" do
-    described_class.perform_now(file)
+    described_class.perform_now(file.id)
     file.reload
     expect(file.presupported).to be false
   end
 
   it "queues analysis job" do
-    expect { described_class.perform_now(file) }.to have_enqueued_job(Scan::AnalyseModelFileJob).once
+    expect { described_class.perform_now(file.id) }.to have_enqueued_job(Scan::AnalyseModelFileJob).once
   end
 end

--- a/spec/jobs/model_scan_job_spec.rb
+++ b/spec/jobs/model_scan_job_spec.rb
@@ -26,17 +26,18 @@ RSpec.describe ModelScanJob do
     end
 
     it "detects model files" do
-      expect { described_class.perform_now(model) }.to change { model.model_files.count }.to(2)
+      expect { described_class.perform_now(model.id) }.to change { model.model_files.count }.to(2)
       expect(model.model_files.map(&:filename)).to eq ["part_1.obj", "part_2.obj"]
     end
 
     it "sets the preview file to the first scanned file by default" do
-      expect { described_class.perform_now(model) }.to change { model.model_files.count }.to(2)
+      expect { described_class.perform_now(model.id) }.to change { model.model_files.count }.to(2)
+      model.reload
       expect(model.preview_file.filename).to eq "part_1.obj"
     end
 
     it "queues up individual file scans" do
-      expect { described_class.perform_now(model) }.to have_enqueued_job(ModelFileScanJob).exactly(2).times
+      expect { described_class.perform_now(model.id) }.to have_enqueued_job(ModelFileScanJob).exactly(2).times
     end
   end
 
@@ -64,12 +65,12 @@ RSpec.describe ModelScanJob do
     let(:thing) { create(:model, path: "thingiverse_model", library: library) }
 
     it "scans files" do
-      expect { described_class.perform_now(thing) }.to change { thing.model_files.count }.to(2)
+      expect { described_class.perform_now(thing.id) }.to change { thing.model_files.count }.to(2)
       expect(thing.model_files.map(&:filename)).to eq ["files/part_one.stl", "images/card_preview_DISPLAY.png"]
     end
 
     it "ignores model-type files in image directory" do
-      expect { described_class.perform_now(thing) }.to change { thing.model_files.count }.to(2)
+      expect { described_class.perform_now(thing.id) }.to change { thing.model_files.count }.to(2)
       expect(thing.model_files.map(&:filename)).not_to include "images/ignore.stl"
     end
   end
@@ -95,7 +96,7 @@ RSpec.describe ModelScanJob do
     let(:model) { create(:model, path: "model", library: library) }
 
     it "finds all the files in the subfolders" do
-      expect { described_class.perform_now(model) }.to change { model.model_files.count }.to(6)
+      expect { described_class.perform_now(model.id) }.to change { model.model_files.count }.to(6)
     end
   end
 
@@ -142,7 +143,7 @@ RSpec.describe ModelScanJob do
     it "doesn't make ModelFile objects for folders" do
       model = create(:model, path: "model", library: mock_library)
       # arm.stl is in a contained model so there should be only one file in this model
-      expect { described_class.perform_now(model) }.to change { model.model_files.count }.to(1)
+      expect { described_class.perform_now(model.id) }.to change { model.model_files.count }.to(1)
       expect(model.model_files.map(&:filename)).not_to include ["nope.stl"]
     end
   end

--- a/spec/jobs/model_scan_job_spec.rb
+++ b/spec/jobs/model_scan_job_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ModelScanJob do
     let(:model) { create(:model, path: "model", library: library) }
 
     it "finds all the files in the subfolders" do
-      expect { described_class.perform_now(model) }.to change { model.model_files.count }.to(6)
+      expect { described_class.perform_now(model.id) }.to change { model.model_files.count }.to(6)
     end
   end
 

--- a/spec/jobs/scan/analyse_model_file_job_spec.rb
+++ b/spec/jobs/scan/analyse_model_file_job_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Scan::AnalyseModelFileJob do
     file = create(:model_file, filename: "test.obj", digest: nil, size: 10)
     allow(File).to receive(:exist?).with(file.pathname).and_return(true)
     allow(file).to receive(:calculate_digest).once.and_return("deadbeef")
-    described_class.perform_now file
+    described_class.perform_now file.id
+    file.reload
     expect(file.digest).to eq "deadbeef"
   end
 
@@ -14,7 +15,8 @@ RSpec.describe Scan::AnalyseModelFileJob do
     file = create(:model_file, filename: "test.obj", digest: "deadbeef", size: nil)
     allow(File).to receive(:exist?).with(file.pathname).and_return(true)
     allow(File).to receive(:size).once.and_return(1234)
-    described_class.perform_now file
+    described_class.perform_now file.id
+    file.reload
     expect(file.size).to eq 1234
   end
 
@@ -22,7 +24,7 @@ RSpec.describe Scan::AnalyseModelFileJob do
     file = create(:model_file, filename: "test.stl", digest: "deadbeef", size: 1234)
     allow(File).to receive(:exist?).with(file.pathname).and_return(true)
     allow(File).to receive(:read).with(file.pathname, 6).once.and_return("solid ")
-    expect { described_class.perform_now file }.to change(Problem, :count).from(0).to(1)
+    expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
     expect(Problem.first.category).to eq "inefficient"
     expect(Problem.first.note).to eq "ASCII STL"
   end
@@ -30,7 +32,7 @@ RSpec.describe Scan::AnalyseModelFileJob do
   it "detects Wavefront OBJ files and creates a Problem record" do
     file = create(:model_file, filename: "test.obj", digest: "deadbeef", size: 1234)
     allow(File).to receive(:exist?).with(file.pathname).and_return(true)
-    expect { described_class.perform_now file }.to change(Problem, :count).from(0).to(1)
+    expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
     expect(Problem.first.category).to eq "inefficient"
     expect(Problem.first.note).to eq "Wavefront OBJ"
   end
@@ -39,7 +41,7 @@ RSpec.describe Scan::AnalyseModelFileJob do
     file = create(:model_file, filename: "test.ply", digest: "deadbeef", size: 1234)
     allow(File).to receive(:exist?).with(file.pathname).and_return(true)
     allow(File).to receive(:read).with(file.pathname, 16).once.and_return("ply\rformat ascii")
-    expect { described_class.perform_now file }.to change(Problem, :count).from(0).to(1)
+    expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
     expect(Problem.first.category).to eq "inefficient"
     expect(Problem.first.note).to eq "ASCII PLY"
   end
@@ -49,7 +51,7 @@ RSpec.describe Scan::AnalyseModelFileJob do
     allow(File).to receive(:exist?).with(file.pathname).and_return(true)
     allow(File).to receive(:read).and_return("whatever")
     allow(file).to receive(:duplicate?).once.and_return(true)
-    expect { described_class.perform_now file }.to change(Problem, :count).from(0).to(1)
+    expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
     expect(Problem.first.category).to eq "duplicate"
   end
 end

--- a/spec/jobs/scan/check_model_integrity_job_spec.rb
+++ b/spec/jobs/scan/check_model_integrity_job_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Scan::CheckModelIntegrityJob do
 
   it "flags models with no folder as a problem" do
     model = create(:model, library: library, path: "missing")
-    expect { described_class.perform_now(model) }.to change(Problem, :count).from(0).to(2)
+    expect { described_class.perform_now(model.id) }.to change(Problem, :count).from(0).to(2)
     expect(model.problems.map(&:category)).to eq ["missing", "empty"]
   end
 
   it "flags up problems for files that don't exist on disk" do
     thing = create(:model, path: "model_one", library: library)
     create(:model_file, filename: "missing.stl", model: thing)
-    expect { described_class.perform_now(thing) }.to change(Problem, :count).from(0).to(1)
+    expect { described_class.perform_now(thing.id) }.to change(Problem, :count).from(0).to(1)
     expect(thing.model_files.first.problems.first.category).to eq "missing"
   end
 end

--- a/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
+++ b/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
@@ -23,18 +23,18 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "can scan a library directory" do
-      expect { described_class.perform_now(library) }.to change { library.models.count }.to(2)
+      expect { described_class.perform_now(library.id) }.to change { library.models.count }.to(2)
       expect(library.models.map(&:path)).to contain_exactly("model_one", "subfolder/model_two")
     end
 
     it "queues up model scans" do
-      expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(2).times
+      expect { described_class.perform_now(library.id) }.to have_enqueued_job(ModelScanJob).exactly(2).times
     end
 
     it "only scans models with changes on rescan" do
       model_one = create(:model, path: "model_one", library: library)
-      ModelScanJob.perform_now(model_one)
-      expect { described_class.perform_now(library) }.to have_enqueued_job(ModelScanJob).exactly(1).times
+      ModelScanJob.perform_now(model_one.id)
+      expect { described_class.perform_now(library.id) }.to have_enqueued_job(ModelScanJob).exactly(1).times
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "pulls out nested model as separate" do
-      expect { described_class.perform_now(library) }.to change { library.models.count }.to(2)
+      expect { described_class.perform_now(library.id) }.to change { library.models.count }.to(2)
       expect(library.models.map(&:path)).to contain_exactly("model_one", "model_one/nested")
     end
   end
@@ -76,7 +76,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "understands that it's a single model" do
-      expect { described_class.perform_now(library) }.to change { library.models.count }.to(1)
+      expect { described_class.perform_now(library.id) }.to change { library.models.count }.to(1)
       expect(library.models.map(&:path)).to contain_exactly("thingiverse_model")
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "understands that it's a single model" do
-      expect { described_class.perform_now(library) }.to change { library.models.count }.to(1)
+      expect { described_class.perform_now(library.id) }.to change { library.models.count }.to(1)
       expect(library.models.map(&:path)).to contain_exactly("model")
     end
   end
@@ -126,7 +126,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "ignores case and filters out subfolders correctly" do
-      expect { described_class.perform_now(library) }.to change { library.models.count }.to(1)
+      expect { described_class.perform_now(library.id) }.to change { library.models.count }.to(1)
       expect(library.models.map(&:path)).to contain_exactly("model")
     end
   end

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ModelFile do
     it "queues up rescans for duplicates on destroy" do
       dupe = create(:model_file, model: model, filename: "duplicate.3mf", digest: "1234")
       expect { file.delete_from_disk_and_destroy }.to(
-        have_enqueued_job(Scan::AnalyseModelFileJob).with(dupe)
+        have_enqueued_job(Scan::AnalyseModelFileJob).with(dupe.id)
       )
     end
   end


### PR DESCRIPTION
If an object is missing by the time it's processed by a scan job, the error will be silently absorbed, instead of blocking up the scan state.